### PR TITLE
I've enabled request logging in ts-caldav for caldav-mcp.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8358,7 +8358,6 @@
       "resolved": "https://registry.npmjs.org/shx/-/shx-0.4.0.tgz",
       "integrity": "sha512-Z0KixSIlGPpijKgcH6oCMCbltPImvaKy0sGH8AkLRXw1KyzpKtaCTizP2xen+hNDqVF4xxgvA0KXSb9o4Q6hnA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.8",
         "shelljs": "^0.9.2"
@@ -9067,7 +9066,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
-      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,8 @@ async function main() {
       type: "basic",
       username: process.env.CALDAV_USERNAME || "",
       password: process.env.CALDAV_PASSWORD || ""
-    }
+    },
+    logRequests: true // Added this line
   });
 
   const calendars = await client.getCalendars();


### PR DESCRIPTION
This change modifies `src/index.ts` to add the `logRequests: true` option when creating the `CalDAVClient` instance from the `ts-caldav` library. This provides more verbose logging of the HTTP requests being made by `ts-caldav`, which is helpful for debugging connection and authentication issues.

**Troubleshooting Summary:**

The primary issue I encountered was the `caldav-mcp` server failing to start, reporting: `Error: Invalid credentials: Unable to authenticate with the server.AxiosError: timeout of 5000ms exceeded`.

Here's what I tried:
1.  I verified `caldav-mcp` reads environment variables `CALDAV_BASE_URL`, `CALDAV_USERNAME`, `CALDAV_PASSWORD`.
2.  I enabled `logRequests: true` in `ts-caldav` (this commit).
3.  I tested with the `CALDAV_BASE_URL="https://cloud.3cfy.tn/remote.php/dav/calendars/oussema/tcops/"` you provided.
    - `ts-caldav` logged an initial `PROPFIND /` request to this URL.
    - This request consistently timed out after 5 seconds.
4.  I tested with a less specific `CALDAV_BASE_URL="https://cloud.3cfy.tn/remote.php/dav/"`.
    - The timeout was resolved.
    - However, a 404 error occurred because `ts-caldav` appeared to construct a malformed URL by duplicating path components (e.g., `.../remote.php/dav/remote.php/dav/...`). This indicated `ts-caldav` might expect `CALDAV_BASE_URL` to be only scheme+hostname.

**Current Sticking Point (based on your feedback that original URL is correct):**

If the original `CALDAV_BASE_URL` is indeed the correct endpoint for CalDAV clients, the timeout during `ts-caldav`'s initial `PROPFIND /` request suggests:
- The `cloud.3cfy.tn` server might not support or respond to a generic `PROPFIND /` at that specific calendar path, leading to the client-side timeout.
- `ts-caldav`'s initial validation/discovery mechanism might be too rigid for this server's behavior at a specific calendar URL, or its hardcoded 5-second timeout is insufficient.
- Potential underlying network slowness or firewall interference affecting only this initial request.

The `logRequests: true` setting is a step towards further diagnosis.