### PR TITLE
fix: prevent $ref deduplication in tool input schemas

### DIFF
--- a/src/tools/create-event.ts
+++ b/src/tools/create-event.ts
@@ -35,8 +35,8 @@ export function registerCreateEvent(client: CalDAVClient, server: McpServer) {
 			description: "Creates an event in the calendar specified by its URL",
 			inputSchema: {
 				summary: z.string(),
-				start: z.string().datetime(),
-				end: z.string().datetime(),
+				start: z.string().datetime().describe("Start datetime (ISO 8601)"),
+				end: z.string().datetime().describe("End datetime (ISO 8601)"),
 				calendarUrl: z.string(),
 				recurrenceRule: recurrenceRuleSchema.optional(),
 			},

--- a/src/tools/list-events.ts
+++ b/src/tools/list-events.ts
@@ -8,10 +8,6 @@ type ListEventsInput = {
 	calendarUrl: string;
 };
 
-const dateString = z.string().refine((val) => !Number.isNaN(Date.parse(val)), {
-	message: "Invalid date string",
-});
-
 export function registerListEvents(client: CalDAVClient, server: McpServer) {
 	server.registerTool(
 		"list-events",
@@ -19,8 +15,18 @@ export function registerListEvents(client: CalDAVClient, server: McpServer) {
 			description:
 				"List all events between start and end date in the calendar specified by its URL",
 			inputSchema: {
-				start: dateString,
-				end: dateString,
+				start: z
+					.string()
+					.refine((val) => !Number.isNaN(Date.parse(val)), {
+						message: "Invalid date string",
+					})
+					.describe("Start date (ISO 8601)"),
+				end: z
+					.string()
+					.refine((val) => !Number.isNaN(Date.parse(val)), {
+						message: "Invalid date string",
+					})
+					.describe("End date (ISO 8601)"),
 				calendarUrl: z.string(),
 			},
 		},


### PR DESCRIPTION
## Problem

The `list-events` and `create-event` tools emit a broken JSON Schema for their `end` parameter:

```json
{
  "properties": {
    "end": { "$ref": "#/properties/start" },
    "start": { "type": "string" }
  }
}
```

This happens because `zodToJsonSchema()` (used internally by `@modelcontextprotocol/sdk`) deduplicates properties that are structurally identical or share the same Zod instance. In `list-events.ts`, `start` and `end` were both assigned the same `dateString` variable — a textbook trigger for this deduplication. In `create-event.ts`, the inline `z.string().datetime()` calls are structurally identical and can also be collapsed.

While `$ref` is technically valid JSON Schema draft-07, many MCP clients do **not** resolve intra-schema `$ref` pointers within `properties`, including Claude and Gemini CLI. The result:

- `end` appears as `any` in client tool listings instead of `string`
- Claude intermittently passes `null` for `end`, causing MCP validation errors at runtime

## Fix

Made `start` and `end` schemas structurally distinct by adding `.describe()` with unique descriptions. This is the minimal change that prevents `zodToJsonSchema` from emitting a `$ref` while preserving all existing validation logic. All existing tests continue to pass.

## Verification

After the fix, the compiled output contains no `$ref` references:
```
grep '$ref' dist/*.js  →  (no output)
```

## Related issues in the ecosystem

- https://github.com/modelcontextprotocol/typescript-sdk/issues/745
- https://github.com/google-gemini/gemini-cli/issues/13326