### PR TITLE
Fix etag fetching before delete, add update-event tool

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,2 @@
-npx biome check --staged --write
+npx biome check --staged --write --no-errors-on-unmatched
 npm test

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 - List calendars
 - List calendar events within a specific timeframe
 - Create calendar events
+- Update calendar events
 - Delete calendar events by UID
 
 ## Setup
@@ -96,6 +97,23 @@ Returns:
   - `summary`: Event title/summary
   - `start`: Event start time
   - `end`: Event end time
+
+### update-event
+
+Updates an existing calendar event. Only provided fields are changed.
+
+Parameters:
+- `uid`: String - Unique identifier of the event to update (obtained from list-events)
+- `calendarUrl`: String - URL of the calendar
+- `summary`: String (optional) - New event title/summary
+- `start`: DateTime string (optional) - New event start time
+- `end`: DateTime string (optional) - New event end time
+- `description`: String (optional) - New event description
+- `location`: String (optional) - New event location
+- `recurrenceRule`: Object (optional) - New recurrence rule
+
+Returns:
+- The unique ID of the updated event
 
 ### delete-event
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import { registerCreateEvent } from "./tools/create-event.js";
 import { registerDeleteEvent } from "./tools/delete-event.js";
 import { registerListCalendars } from "./tools/list-calendars.js";
 import { registerListEvents } from "./tools/list-events.js";
+import { registerUpdateEvent } from "./tools/update-event.js";
 
 const server = new McpServer({
 	name: "caldav-mcp",
@@ -35,6 +36,7 @@ async function main() {
 	registerCreateEvent(client, server);
 	registerListEvents(client, server);
 	registerDeleteEvent(client, server);
+	registerUpdateEvent(client, server);
 	await registerListCalendars(client, server);
 
 	// Start receiving messages on stdin and sending messages on stdout

--- a/src/tools/create-event.ts
+++ b/src/tools/create-event.ts
@@ -35,8 +35,14 @@ export function registerCreateEvent(client: CalDAVClient, server: McpServer) {
 			description: "Creates an event in the calendar specified by its URL",
 			inputSchema: {
 				summary: z.string(),
-				start: z.string().datetime({ offset: true }).describe("Start datetime (ISO 8601)"),
-				end: z.string().datetime({ offset: true }).describe("End datetime (ISO 8601)"),
+				start: z
+					.string()
+					.datetime({ offset: true })
+					.describe("Start datetime (ISO 8601)"),
+				end: z
+					.string()
+					.datetime({ offset: true })
+					.describe("End datetime (ISO 8601)"),
 				calendarUrl: z.string(),
 				recurrenceRule: recurrenceRuleSchema.optional(),
 			},

--- a/src/tools/create-event.ts
+++ b/src/tools/create-event.ts
@@ -22,7 +22,7 @@ const recurrenceRuleSchema = z.object({
 	freq: z.enum(["DAILY", "WEEKLY", "MONTHLY", "YEARLY"]).optional(),
 	interval: z.number().optional(),
 	count: z.number().optional(),
-	until: z.string().datetime().optional(), // ISO 8601 string
+	until: z.string().datetime({ offset: true }).optional(), // ISO 8601 string
 	byday: z.array(z.string()).optional(), // e.g. ["MO", "TU"]
 	bymonthday: z.array(z.number()).optional(),
 	bymonth: z.array(z.number()).optional(),
@@ -35,8 +35,8 @@ export function registerCreateEvent(client: CalDAVClient, server: McpServer) {
 			description: "Creates an event in the calendar specified by its URL",
 			inputSchema: {
 				summary: z.string(),
-				start: z.string().datetime(),
-				end: z.string().datetime(),
+				start: z.string().datetime({ offset: true }),
+				end: z.string().datetime({ offset: true }),
 				calendarUrl: z.string(),
 				recurrenceRule: recurrenceRuleSchema.optional(),
 			},

--- a/src/tools/delete-event.test.ts
+++ b/src/tools/delete-event.test.ts
@@ -81,9 +81,7 @@ describe("registerDeleteEvent", () => {
 		});
 
 		// etag must be fetched from the constructed href
-		expect(mockClient.getETag).toHaveBeenCalledWith(
-			"/cal/work/meeting-42.ics",
-		);
+		expect(mockClient.getETag).toHaveBeenCalledWith("/cal/work/meeting-42.ics");
 
 		// the fetched etag is forwarded to deleteEvent (not "*")
 		expect(mockClient.deleteEvent).toHaveBeenCalledWith(

--- a/src/tools/delete-event.test.ts
+++ b/src/tools/delete-event.test.ts
@@ -10,8 +10,8 @@ type ToolHandler = (params: {
 
 describe("registerDeleteEvent", () => {
 	test("successfully deletes event when server returns 204", async () => {
-		// Create mock CalDAV client that returns 204 (No Content)
 		const mockClient = {
+			getETag: vi.fn().mockResolvedValue('"abc123"'),
 			deleteEvent: vi.fn().mockResolvedValue(undefined),
 		};
 
@@ -31,7 +31,7 @@ describe("registerDeleteEvent", () => {
 			},
 		) as typeof server.registerTool;
 
-		registerDeleteEvent(mockClient as CalDAVClient, server);
+		registerDeleteEvent(mockClient as unknown as CalDAVClient, server);
 
 		expect(toolHandler).toBeDefined();
 
@@ -41,16 +41,19 @@ describe("registerDeleteEvent", () => {
 		});
 
 		expect(result.content[0].text).toBe("Event deleted");
+		expect(mockClient.getETag).toHaveBeenCalledWith(
+			"/f/test-calendar/event-123.ics",
+		);
 		expect(mockClient.deleteEvent).toHaveBeenCalledWith(
 			"/f/test-calendar/",
 			"event-123",
+			'"abc123"',
 		);
 	});
 
 	test("successfully deletes event when server returns 200", async () => {
-		// Create mock CalDAV client
-		// In practice, ts-caldav should accept both 200 and 204 status codes
 		const mockClient = {
+			getETag: vi.fn().mockResolvedValue('"def456"'),
 			deleteEvent: vi.fn().mockResolvedValue(undefined),
 		};
 
@@ -70,19 +73,23 @@ describe("registerDeleteEvent", () => {
 			},
 		) as typeof server.registerTool;
 
-		registerDeleteEvent(mockClient as CalDAVClient, server);
+		registerDeleteEvent(mockClient as unknown as CalDAVClient, server);
 
 		expect(toolHandler).toBeDefined();
 
 		const result = await toolHandler({
-			calendarUrl: "/f/test-calendar/",
+			calendarUrl: "/f/test-calendar",
 			uid: "event-456",
 		});
 
 		expect(result.content[0].text).toBe("Event deleted");
+		expect(mockClient.getETag).toHaveBeenCalledWith(
+			"/f/test-calendar/event-456.ics",
+		);
 		expect(mockClient.deleteEvent).toHaveBeenCalledWith(
-			"/f/test-calendar/",
+			"/f/test-calendar",
 			"event-456",
+			'"def456"',
 		);
 	});
 });

--- a/src/tools/delete-event.test.ts
+++ b/src/tools/delete-event.test.ts
@@ -51,6 +51,53 @@ describe("registerDeleteEvent", () => {
 		);
 	});
 
+	test("fetches etag before deleting and passes it to deleteEvent", async () => {
+		const mockClient = {
+			getETag: vi.fn().mockResolvedValue('"etag-from-server"'),
+			deleteEvent: vi.fn().mockResolvedValue(undefined),
+		};
+
+		let toolHandler: ToolHandler | null = null;
+		const server = new McpServer({
+			name: "test-server",
+			version: "0.1.0",
+		});
+
+		const originalRegisterTool = server.registerTool.bind(server);
+		server.registerTool = vi.fn(
+			(name: string, config: unknown, handler: ToolHandler) => {
+				if (name === "delete-event") {
+					toolHandler = handler;
+				}
+				return originalRegisterTool(name, config, handler);
+			},
+		) as typeof server.registerTool;
+
+		registerDeleteEvent(mockClient as unknown as CalDAVClient, server);
+
+		await toolHandler({
+			calendarUrl: "/cal/work/",
+			uid: "meeting-42",
+		});
+
+		// etag must be fetched from the constructed href
+		expect(mockClient.getETag).toHaveBeenCalledWith(
+			"/cal/work/meeting-42.ics",
+		);
+
+		// the fetched etag is forwarded to deleteEvent (not "*")
+		expect(mockClient.deleteEvent).toHaveBeenCalledWith(
+			"/cal/work/",
+			"meeting-42",
+			'"etag-from-server"',
+		);
+
+		// getETag is called before deleteEvent
+		const etagOrder = mockClient.getETag.mock.invocationCallOrder[0];
+		const deleteOrder = mockClient.deleteEvent.mock.invocationCallOrder[0];
+		expect(etagOrder).toBeLessThan(deleteOrder);
+	});
+
 	test("successfully deletes event when server returns 200", async () => {
 		const mockClient = {
 			getETag: vi.fn().mockResolvedValue('"def456"'),

--- a/src/tools/delete-event.ts
+++ b/src/tools/delete-event.ts
@@ -16,7 +16,10 @@ export function registerDeleteEvent(client: CalDAVClient, server: McpServer) {
 		},
 		async (args: DeleteEventInput) => {
 			const { uid, calendarUrl } = args;
-			await client.deleteEvent(calendarUrl, uid);
+			const base = calendarUrl.endsWith("/") ? calendarUrl : `${calendarUrl}/`;
+			const href = `${base}${uid}.ics`;
+			const etag = await client.getETag(href);
+			await client.deleteEvent(calendarUrl, uid, etag);
 
 			return {
 				content: [{ type: "text", text: "Event deleted" }],

--- a/src/tools/update-event.test.ts
+++ b/src/tools/update-event.test.ts
@@ -39,7 +39,14 @@ describe("registerUpdateEvent", () => {
 	test("updates only the provided fields", async () => {
 		const mockClient = {
 			getEventsByHref: vi.fn().mockResolvedValue([existingEvent]),
-			updateEvent: vi.fn().mockResolvedValue({ uid: "event-123", href: existingEvent.href, etag: '"new-etag"', newCtag: "" }),
+			updateEvent: vi
+				.fn()
+				.mockResolvedValue({
+					uid: "event-123",
+					href: existingEvent.href,
+					etag: '"new-etag"',
+					newCtag: "",
+				}),
 		};
 
 		const { server, getHandler } = makeServer();
@@ -89,7 +96,14 @@ describe("registerUpdateEvent", () => {
 	test("appends trailing slash to calendarUrl when building href", async () => {
 		const mockClient = {
 			getEventsByHref: vi.fn().mockResolvedValue([existingEvent]),
-			updateEvent: vi.fn().mockResolvedValue({ uid: "event-123", href: existingEvent.href, etag: '"new-etag"', newCtag: "" }),
+			updateEvent: vi
+				.fn()
+				.mockResolvedValue({
+					uid: "event-123",
+					href: existingEvent.href,
+					etag: '"new-etag"',
+					newCtag: "",
+				}),
 		};
 
 		const { server, getHandler } = makeServer();

--- a/src/tools/update-event.test.ts
+++ b/src/tools/update-event.test.ts
@@ -39,14 +39,12 @@ describe("registerUpdateEvent", () => {
 	test("updates only the provided fields", async () => {
 		const mockClient = {
 			getEventsByHref: vi.fn().mockResolvedValue([existingEvent]),
-			updateEvent: vi
-				.fn()
-				.mockResolvedValue({
-					uid: "event-123",
-					href: existingEvent.href,
-					etag: '"new-etag"',
-					newCtag: "",
-				}),
+			updateEvent: vi.fn().mockResolvedValue({
+				uid: "event-123",
+				href: existingEvent.href,
+				etag: '"new-etag"',
+				newCtag: "",
+			}),
 		};
 
 		const { server, getHandler } = makeServer();
@@ -96,14 +94,12 @@ describe("registerUpdateEvent", () => {
 	test("appends trailing slash to calendarUrl when building href", async () => {
 		const mockClient = {
 			getEventsByHref: vi.fn().mockResolvedValue([existingEvent]),
-			updateEvent: vi
-				.fn()
-				.mockResolvedValue({
-					uid: "event-123",
-					href: existingEvent.href,
-					etag: '"new-etag"',
-					newCtag: "",
-				}),
+			updateEvent: vi.fn().mockResolvedValue({
+				uid: "event-123",
+				href: existingEvent.href,
+				etag: '"new-etag"',
+				newCtag: "",
+			}),
 		};
 
 		const { server, getHandler } = makeServer();

--- a/src/tools/update-event.test.ts
+++ b/src/tools/update-event.test.ts
@@ -1,0 +1,106 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { CalDAVClient, Event } from "ts-caldav";
+import { describe, expect, test, vi } from "vitest";
+import { registerUpdateEvent } from "./update-event.js";
+
+type ToolHandler = (params: {
+	uid: string;
+	calendarUrl: string;
+	summary?: string;
+	start?: string;
+	end?: string;
+	description?: string;
+	location?: string;
+}) => Promise<{ content: { type: string; text: string }[] }>;
+
+const existingEvent: Event = {
+	uid: "event-123",
+	href: "/f/test-calendar/event-123.ics",
+	etag: '"abc123"',
+	summary: "Original summary",
+	start: new Date("2026-04-03T10:00:00Z"),
+	end: new Date("2026-04-03T11:00:00Z"),
+};
+
+function makeServer() {
+	let toolHandler: ToolHandler | null = null;
+	const server = new McpServer({ name: "test-server", version: "0.1.0" });
+	const originalRegisterTool = server.registerTool.bind(server);
+	server.registerTool = vi.fn(
+		(name: string, config: unknown, handler: ToolHandler) => {
+			if (name === "update-event") toolHandler = handler;
+			return originalRegisterTool(name, config, handler);
+		},
+	) as typeof server.registerTool;
+	return { server, getHandler: () => toolHandler };
+}
+
+describe("registerUpdateEvent", () => {
+	test("updates only the provided fields", async () => {
+		const mockClient = {
+			getEventsByHref: vi.fn().mockResolvedValue([existingEvent]),
+			updateEvent: vi.fn().mockResolvedValue({ uid: "event-123", href: existingEvent.href, etag: '"new-etag"', newCtag: "" }),
+		};
+
+		const { server, getHandler } = makeServer();
+		registerUpdateEvent(mockClient as unknown as CalDAVClient, server);
+		const handler = getHandler()!;
+
+		const result = await handler({
+			uid: "event-123",
+			calendarUrl: "/f/test-calendar/",
+			summary: "Updated summary",
+		});
+
+		expect(result.content[0].text).toBe("event-123");
+		expect(mockClient.getEventsByHref).toHaveBeenCalledWith(
+			"/f/test-calendar/",
+			["/f/test-calendar/event-123.ics"],
+		);
+		expect(mockClient.updateEvent).toHaveBeenCalledWith(
+			"/f/test-calendar/",
+			expect.objectContaining({
+				uid: "event-123",
+				etag: '"abc123"',
+				summary: "Updated summary",
+				start: existingEvent.start,
+				end: existingEvent.end,
+			}),
+		);
+	});
+
+	test("throws when event is not found", async () => {
+		const mockClient = {
+			getEventsByHref: vi.fn().mockResolvedValue([]),
+			updateEvent: vi.fn(),
+		};
+
+		const { server, getHandler } = makeServer();
+		registerUpdateEvent(mockClient as unknown as CalDAVClient, server);
+		const handler = getHandler()!;
+
+		await expect(
+			handler({ uid: "missing", calendarUrl: "/f/test-calendar/" }),
+		).rejects.toThrow("Event not found: missing");
+
+		expect(mockClient.updateEvent).not.toHaveBeenCalled();
+	});
+
+	test("appends trailing slash to calendarUrl when building href", async () => {
+		const mockClient = {
+			getEventsByHref: vi.fn().mockResolvedValue([existingEvent]),
+			updateEvent: vi.fn().mockResolvedValue({ uid: "event-123", href: existingEvent.href, etag: '"new-etag"', newCtag: "" }),
+		};
+
+		const { server, getHandler } = makeServer();
+		registerUpdateEvent(mockClient as unknown as CalDAVClient, server);
+		const handler = getHandler()!;
+
+		await handler({ uid: "event-123", calendarUrl: "/f/test-calendar" });
+
+		expect(mockClient.getEventsByHref).toHaveBeenCalledWith(
+			"/f/test-calendar",
+			["/f/test-calendar/event-123.ics"],
+		);
+	});
+});

--- a/src/tools/update-event.ts
+++ b/src/tools/update-event.ts
@@ -1,0 +1,77 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { CalDAVClient, RecurrenceRule } from "ts-caldav";
+import { z } from "zod";
+
+type UpdateEventInput = {
+	uid: string;
+	calendarUrl: string;
+	summary?: string;
+	start?: string;
+	end?: string;
+	description?: string;
+	location?: string;
+	recurrenceRule?: {
+		freq?: "DAILY" | "WEEKLY" | "MONTHLY" | "YEARLY";
+		interval?: number;
+		count?: number;
+		until?: string;
+		byday?: string[];
+		bymonthday?: number[];
+		bymonth?: number[];
+	};
+};
+
+const recurrenceRuleSchema = z.object({
+	freq: z.enum(["DAILY", "WEEKLY", "MONTHLY", "YEARLY"]).optional(),
+	interval: z.number().optional(),
+	count: z.number().optional(),
+	until: z.string().datetime().optional(),
+	byday: z.array(z.string()).optional(),
+	bymonthday: z.array(z.number()).optional(),
+	bymonth: z.array(z.number()).optional(),
+});
+
+export function registerUpdateEvent(client: CalDAVClient, server: McpServer) {
+	server.registerTool(
+		"update-event",
+		{
+			description:
+				"Updates an existing event in the calendar specified by its URL. Only provided fields are changed.",
+			inputSchema: {
+				uid: z.string(),
+				calendarUrl: z.string(),
+				summary: z.string().optional(),
+				start: z.string().datetime().optional(),
+				end: z.string().datetime().optional(),
+				description: z.string().optional(),
+				location: z.string().optional(),
+				recurrenceRule: recurrenceRuleSchema.optional(),
+			},
+		},
+		async (args: UpdateEventInput) => {
+			const { uid, calendarUrl, summary, start, end, description, location, recurrenceRule } = args;
+
+			const base = calendarUrl.endsWith("/") ? calendarUrl : `${calendarUrl}/`;
+			const href = `${base}${uid}.ics`;
+
+			const [existing] = await client.getEventsByHref(calendarUrl, [href]);
+			if (!existing) {
+				throw new Error(`Event not found: ${uid}`);
+			}
+
+			const updated = await client.updateEvent(calendarUrl, {
+				...existing,
+				...(summary !== undefined && { summary }),
+				...(start !== undefined && { start: new Date(start) }),
+				...(end !== undefined && { end: new Date(end) }),
+				...(description !== undefined && { description }),
+				...(location !== undefined && { location }),
+				...(recurrenceRule !== undefined && { recurrenceRule: recurrenceRule as RecurrenceRule }),
+			});
+
+			return {
+				content: [{ type: "text", text: updated.uid }],
+			};
+		},
+	);
+}

--- a/src/tools/update-event.ts
+++ b/src/tools/update-event.ts
@@ -25,7 +25,7 @@ const recurrenceRuleSchema = z.object({
 	freq: z.enum(["DAILY", "WEEKLY", "MONTHLY", "YEARLY"]).optional(),
 	interval: z.number().optional(),
 	count: z.number().optional(),
-	until: z.string().datetime().optional(),
+	until: z.string().datetime({ offset: true }).optional(),
 	byday: z.array(z.string()).optional(),
 	bymonthday: z.array(z.number()).optional(),
 	bymonth: z.array(z.number()).optional(),
@@ -41,15 +41,24 @@ export function registerUpdateEvent(client: CalDAVClient, server: McpServer) {
 				uid: z.string(),
 				calendarUrl: z.string(),
 				summary: z.string().optional(),
-				start: z.string().datetime().optional(),
-				end: z.string().datetime().optional(),
+				start: z.string().datetime({ offset: true }).optional(),
+				end: z.string().datetime({ offset: true }).optional(),
 				description: z.string().optional(),
 				location: z.string().optional(),
 				recurrenceRule: recurrenceRuleSchema.optional(),
 			},
 		},
 		async (args: UpdateEventInput) => {
-			const { uid, calendarUrl, summary, start, end, description, location, recurrenceRule } = args;
+			const {
+				uid,
+				calendarUrl,
+				summary,
+				start,
+				end,
+				description,
+				location,
+				recurrenceRule,
+			} = args;
 
 			const base = calendarUrl.endsWith("/") ? calendarUrl : `${calendarUrl}/`;
 			const href = `${base}${uid}.ics`;
@@ -66,7 +75,9 @@ export function registerUpdateEvent(client: CalDAVClient, server: McpServer) {
 				...(end !== undefined && { end: new Date(end) }),
 				...(description !== undefined && { description }),
 				...(location !== undefined && { location }),
-				...(recurrenceRule !== undefined && { recurrenceRule: recurrenceRule as RecurrenceRule }),
+				...(recurrenceRule !== undefined && {
+					recurrenceRule: recurrenceRule as RecurrenceRule,
+				}),
 			});
 
 			return {


### PR DESCRIPTION
The server was not fetching etag before deleting of events, which caused the default * to be used. Some servers like iCloud reject this 

Also while I'm at it, add an update-event tool