### PR TITLE
feat(create-event): support description and location

### DIFF
--- a/src/tools/create-event.ts
+++ b/src/tools/create-event.ts
@@ -7,6 +7,8 @@ type CreateEventInput = {
 	start: string;
 	end: string;
 	calendarUrl: string;
+	description?: string;
+	location?: string;
 	recurrenceRule?: {
 		freq?: "DAILY" | "WEEKLY" | "MONTHLY" | "YEARLY";
 		interval?: number;
@@ -44,15 +46,27 @@ export function registerCreateEvent(client: CalDAVClient, server: McpServer) {
 					.datetime({ offset: true })
 					.describe("End datetime (ISO 8601)"),
 				calendarUrl: z.string(),
+				description: z.string().optional(),
+				location: z.string().optional(),
 				recurrenceRule: recurrenceRuleSchema.optional(),
 			},
 		},
 		async (args: CreateEventInput) => {
-			const { calendarUrl, summary, start, end, recurrenceRule } = args;
+			const {
+				calendarUrl,
+				summary,
+				start,
+				end,
+				description,
+				location,
+				recurrenceRule,
+			} = args;
 			const event = await client.createEvent(calendarUrl, {
 				summary: summary,
 				start: new Date(start),
 				end: new Date(end),
+				...(description !== undefined && { description }),
+				...(location !== undefined && { location }),
 				recurrenceRule: recurrenceRule as RecurrenceRule,
 			});
 


### PR DESCRIPTION
## Summary

`create-event` currently only accepts `summary`, `start`, `end`, `calendarUrl`, and `recurrenceRule`, while `update-event` already supports `description` and `location`. The underlying `ts-caldav` `Event` interface accepts both on `createEvent`, so this is asymmetry in the MCP layer rather than a library limitation.

This PR makes `create-event` accept the same `description` and `location` fields, so callers can set the body of the event in one round trip instead of `create` + `update`.

## Changes

- `src/tools/create-event.ts`: add optional `description` and `location` to `CreateEventInput` type and the Zod input schema; conditionally spread them into the `client.createEvent` payload (same pattern as `update-event`).

## Test plan

- [x] `npm run validate` (biome check + vitest + tsc) passes locally.
- [x] Tested end-to-end against a Radicale instance: `create-event` with `description` produces an event whose body is visible in DAVx⁵/Thunderbird without a follow-up `update`.