### PR TITLE
chore(lefthook): add gitleaks secret scanning to pre-commit

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thank you for contributing to caldav-mcp! This guide will help you get started.
 
 ## Development Setup
 
-1. **Prerequisites**: Node.js >= 18.0.0, npm >= 9.0.0
+1. **Prerequisites**: Node.js >= 18.0.0, npm >= 9.0.0, [gitleaks](https://github.com/gitleaks/gitleaks) (used by the pre-commit hook; `brew install gitleaks`)
 2. **Clone and install**:
    ```bash
    git clone https://github.com/dominik1001/caldav-mcp.git

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,6 +1,8 @@
 pre-commit:
   parallel: false
   commands:
+    gitleaks:
+      run: gitleaks git --staged --redact --no-banner
     biome:
       run: npx biome check --staged --write --no-errors-on-unmatched
       stage_fixed: true


### PR DESCRIPTION
## Summary
- Adds a `gitleaks git --staged --redact` step as the first `pre-commit` command in `lefthook.yml`, so credential leaks (e.g. CalDAV creds copied from `.env`) fail fast before biome/docs/validate run.
- Documents `gitleaks` as a contributor prerequisite in `CONTRIBUTING.md` with a `brew install` hint.

Motivation: surfaced by a vibe-check of the repo — secret scanning was the only meaningful gap in an otherwise solid pre-commit pipeline.

## Test plan
- [x] `gitleaks git --staged --redact --no-banner` runs clean on the current tree (exit 0)
- [x] Full `lefthook` pre-commit pipeline runs on this commit (biome + gitleaks + validate all pass)
- [ ] Contributors without `gitleaks` installed get a clear "command not found" error from the hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)