### PR TITLE
chore(tsconfig): enable noUncheckedIndexedAccess + exactOptionalPropertyTypes

### DIFF
--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -2,13 +2,19 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 
-type ToolResult = { content: Array<{ type: string; text: string }> };
+type ToolResult = {
+	content: Array<{ type: string; text: string }>;
+	isError?: boolean;
+};
 
 function unwrapText(result: unknown): string {
 	const r = result as ToolResult;
 	const first = r.content?.[0];
 	if (!first || first.type !== "text") {
 		throw new Error(`Unexpected tool result shape: ${JSON.stringify(result)}`);
+	}
+	if (r.isError) {
+		throw new Error(`Tool returned error: ${first.text}`);
 	}
 	return first.text;
 }
@@ -139,6 +145,37 @@ async function main() {
 	if (after.some((e) => e.uid === updatedUid))
 		throw new Error(`Event ${updatedUid} still present after delete`);
 	log("verified deletion");
+
+	// End-to-end coverage for recurring events. Specific `until` → Date
+	// conversion is asserted in create-event.test.ts / update-event.test.ts;
+	// here we just verify the recurrence path round-trips through ts-caldav
+	// against a real CalDAV server.
+	const recurStart = new Date(Date.now() + 2 * 60 * 60 * 1000);
+	const recurEnd = new Date(recurStart.getTime() + 30 * 60 * 1000);
+	const recurUid = unwrapText(
+		await client.callTool({
+			name: "create-event",
+			arguments: {
+				summary: `caldav-mcp smoke recur ${recurStart.toISOString()}`,
+				start: recurStart.toISOString(),
+				end: recurEnd.toISOString(),
+				calendarUrl,
+				recurrenceRule: {
+					freq: "DAILY",
+					count: 3,
+				},
+			},
+		}),
+	);
+	log("created recurring event", recurUid);
+
+	unwrapText(
+		await client.callTool({
+			name: "delete-event",
+			arguments: { uid: recurUid, calendarUrl },
+		}),
+	);
+	log("deleted recurring event");
 
 	await client.close();
 	console.log("\n✅ smoke test passed");

--- a/src/tools/create-event.test.ts
+++ b/src/tools/create-event.test.ts
@@ -1,7 +1,83 @@
-import { describe, test } from "vitest";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { CalDAVClient } from "ts-caldav";
+import { describe, expect, test, vi } from "vitest";
+import { registerCreateEvent } from "./create-event.js";
+
+type ToolHandler = (params: {
+	summary: string;
+	start: string;
+	end: string;
+	calendarUrl: string;
+	description?: string;
+	location?: string;
+	recurrenceRule?: {
+		freq?: "DAILY" | "WEEKLY" | "MONTHLY" | "YEARLY";
+		interval?: number;
+		count?: number;
+		until?: string;
+		byday?: string[];
+		bymonthday?: number[];
+		bymonth?: number[];
+	};
+}) => Promise<{ content: { type: string; text: string }[] }>;
+
+function makeServer() {
+	let toolHandler: ToolHandler | null = null;
+	const server = new McpServer({ name: "test-server", version: "0.1.0" });
+	const originalRegisterTool = server.registerTool.bind(server);
+	server.registerTool = vi.fn(
+		(name: string, config: unknown, handler: ToolHandler) => {
+			if (name === "create-event") toolHandler = handler;
+			return originalRegisterTool(name, config, handler);
+		},
+	) as typeof server.registerTool;
+	return { server, getHandler: () => toolHandler };
+}
 
 describe("registerCreateEvent", () => {
-	test("to be implemented", () => {
-		// TODO: Implement tests for create-event tool
+	test("converts recurrenceRule.until from ISO string to Date", async () => {
+		const mockClient = {
+			createEvent: vi.fn().mockResolvedValue({ uid: "event-123" }),
+		};
+
+		const { server, getHandler } = makeServer();
+		registerCreateEvent(mockClient as unknown as CalDAVClient, server);
+		const handler = getHandler();
+		if (!handler) throw new Error("handler not registered");
+
+		const untilIso = "2026-05-15T10:00:00.000Z";
+		await handler({
+			summary: "Recurring",
+			start: "2026-05-12T10:00:00.000Z",
+			end: "2026-05-12T10:30:00.000Z",
+			calendarUrl: "/f/test-calendar/",
+			recurrenceRule: { freq: "DAILY", until: untilIso },
+		});
+
+		const passed = mockClient.createEvent.mock.calls[0]?.[1];
+		expect(passed?.recurrenceRule?.until).toBeInstanceOf(Date);
+		expect(passed?.recurrenceRule?.until?.toISOString()).toBe(untilIso);
+		expect(passed?.recurrenceRule?.freq).toBe("DAILY");
+	});
+
+	test("omits recurrenceRule when not provided", async () => {
+		const mockClient = {
+			createEvent: vi.fn().mockResolvedValue({ uid: "event-123" }),
+		};
+
+		const { server, getHandler } = makeServer();
+		registerCreateEvent(mockClient as unknown as CalDAVClient, server);
+		const handler = getHandler();
+		if (!handler) throw new Error("handler not registered");
+
+		await handler({
+			summary: "One-off",
+			start: "2026-05-12T10:00:00.000Z",
+			end: "2026-05-12T10:30:00.000Z",
+			calendarUrl: "/f/test-calendar/",
+		});
+
+		const passed = mockClient.createEvent.mock.calls[0]?.[1];
+		expect(passed?.recurrenceRule).toBeUndefined();
 	});
 });

--- a/src/tools/create-event.ts
+++ b/src/tools/create-event.ts
@@ -2,23 +2,37 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { CalDAVClient, RecurrenceRule } from "ts-caldav";
 import { z } from "zod";
 
+type RecurrenceRuleInput = {
+	freq?: "DAILY" | "WEEKLY" | "MONTHLY" | "YEARLY" | undefined;
+	interval?: number | undefined;
+	count?: number | undefined;
+	until?: string | undefined;
+	byday?: string[] | undefined;
+	bymonthday?: number[] | undefined;
+	bymonth?: number[] | undefined;
+};
+
 type CreateEventInput = {
 	summary: string;
 	start: string;
 	end: string;
 	calendarUrl: string;
-	description?: string;
-	location?: string;
-	recurrenceRule?: {
-		freq?: "DAILY" | "WEEKLY" | "MONTHLY" | "YEARLY";
-		interval?: number;
-		count?: number;
-		until?: string;
-		byday?: string[];
-		bymonthday?: number[];
-		bymonth?: number[];
-	};
+	description?: string | undefined;
+	location?: string | undefined;
+	recurrenceRule?: RecurrenceRuleInput | undefined;
 };
+
+function toRecurrenceRule(r: RecurrenceRuleInput): RecurrenceRule {
+	const out: RecurrenceRule = {};
+	if (r.freq !== undefined) out.freq = r.freq;
+	if (r.interval !== undefined) out.interval = r.interval;
+	if (r.count !== undefined) out.count = r.count;
+	if (r.until !== undefined) out.until = new Date(r.until);
+	if (r.byday !== undefined) out.byday = r.byday;
+	if (r.bymonthday !== undefined) out.bymonthday = r.bymonthday;
+	if (r.bymonth !== undefined) out.bymonth = r.bymonth;
+	return out;
+}
 
 const recurrenceRuleSchema = z.object({
 	freq: z.enum(["DAILY", "WEEKLY", "MONTHLY", "YEARLY"]).optional(),
@@ -74,7 +88,9 @@ export function registerCreateEvent(client: CalDAVClient, server: McpServer) {
 				end: new Date(end),
 				...(description !== undefined && { description }),
 				...(location !== undefined && { location }),
-				recurrenceRule: recurrenceRule as RecurrenceRule,
+				...(recurrenceRule !== undefined && {
+					recurrenceRule: toRecurrenceRule(recurrenceRule),
+				}),
 			});
 
 			return {

--- a/src/tools/update-event.test.ts
+++ b/src/tools/update-event.test.ts
@@ -11,6 +11,15 @@ type ToolHandler = (params: {
 	end?: string;
 	description?: string;
 	location?: string;
+	recurrenceRule?: {
+		freq?: "DAILY" | "WEEKLY" | "MONTHLY" | "YEARLY";
+		interval?: number;
+		count?: number;
+		until?: string;
+		byday?: string[];
+		bymonthday?: number[];
+		bymonth?: number[];
+	};
 }) => Promise<{ content: { type: string; text: string }[] }>;
 
 const existingEvent: Event = {
@@ -112,5 +121,34 @@ describe("registerUpdateEvent", () => {
 			"/f/test-calendar",
 			["/f/test-calendar/event-123.ics"],
 		);
+	});
+
+	test("converts recurrenceRule.until from ISO string to Date", async () => {
+		const mockClient = {
+			getEventsByHref: vi.fn().mockResolvedValue([existingEvent]),
+			updateEvent: vi.fn().mockResolvedValue({
+				uid: "event-123",
+				href: existingEvent.href,
+				etag: '"new-etag"',
+				newCtag: "",
+			}),
+		};
+
+		const { server, getHandler } = makeServer();
+		registerUpdateEvent(mockClient as unknown as CalDAVClient, server);
+		const handler = getHandler();
+		if (!handler) throw new Error("handler not registered");
+
+		const untilIso = "2026-05-15T10:00:00.000Z";
+		await handler({
+			uid: "event-123",
+			calendarUrl: "/f/test-calendar/",
+			recurrenceRule: { freq: "DAILY", until: untilIso },
+		});
+
+		const passed = mockClient.updateEvent.mock.calls[0]?.[1];
+		expect(passed?.recurrenceRule?.until).toBeInstanceOf(Date);
+		expect(passed?.recurrenceRule?.until?.toISOString()).toBe(untilIso);
+		expect(passed?.recurrenceRule?.freq).toBe("DAILY");
 	});
 });

--- a/src/tools/update-event.ts
+++ b/src/tools/update-event.ts
@@ -2,24 +2,38 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { CalDAVClient, RecurrenceRule } from "ts-caldav";
 import { z } from "zod";
 
+type RecurrenceRuleInput = {
+	freq?: "DAILY" | "WEEKLY" | "MONTHLY" | "YEARLY" | undefined;
+	interval?: number | undefined;
+	count?: number | undefined;
+	until?: string | undefined;
+	byday?: string[] | undefined;
+	bymonthday?: number[] | undefined;
+	bymonth?: number[] | undefined;
+};
+
 type UpdateEventInput = {
 	uid: string;
 	calendarUrl: string;
-	summary?: string;
-	start?: string;
-	end?: string;
-	description?: string;
-	location?: string;
-	recurrenceRule?: {
-		freq?: "DAILY" | "WEEKLY" | "MONTHLY" | "YEARLY";
-		interval?: number;
-		count?: number;
-		until?: string;
-		byday?: string[];
-		bymonthday?: number[];
-		bymonth?: number[];
-	};
+	summary?: string | undefined;
+	start?: string | undefined;
+	end?: string | undefined;
+	description?: string | undefined;
+	location?: string | undefined;
+	recurrenceRule?: RecurrenceRuleInput | undefined;
 };
+
+function toRecurrenceRule(r: RecurrenceRuleInput): RecurrenceRule {
+	const out: RecurrenceRule = {};
+	if (r.freq !== undefined) out.freq = r.freq;
+	if (r.interval !== undefined) out.interval = r.interval;
+	if (r.count !== undefined) out.count = r.count;
+	if (r.until !== undefined) out.until = new Date(r.until);
+	if (r.byday !== undefined) out.byday = r.byday;
+	if (r.bymonthday !== undefined) out.bymonthday = r.bymonthday;
+	if (r.bymonth !== undefined) out.bymonth = r.bymonth;
+	return out;
+}
 
 const recurrenceRuleSchema = z.object({
 	freq: z.enum(["DAILY", "WEEKLY", "MONTHLY", "YEARLY"]).optional(),
@@ -87,7 +101,7 @@ export function registerUpdateEvent(client: CalDAVClient, server: McpServer) {
 				...(description !== undefined && { description }),
 				...(location !== undefined && { location }),
 				...(recurrenceRule !== undefined && {
-					recurrenceRule: recurrenceRule as RecurrenceRule,
+					recurrenceRule: toRecurrenceRule(recurrenceRule),
 				}),
 			});
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,8 @@
 		"module": "ESNext",
 		"moduleResolution": "bundler",
 		"strict": true,
+		"noUncheckedIndexedAccess": true,
+		"exactOptionalPropertyTypes": true,
 		"esModuleInterop": true,
 		"skipLibCheck": true,
 		"forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
## Summary
- Adds `noUncheckedIndexedAccess` and `exactOptionalPropertyTypes` to `tsconfig.json` (per the agentic engineering vibe-check follow-up).
- Replaces the `recurrenceRule as RecurrenceRule` cast in `create-event.ts` and `update-event.ts` with a `toRecurrenceRule` helper. The cast was hiding a latent bug: `RecurrenceRuleInput.until` is an ISO string, but `ts-caldav`'s `RecurrenceRule.until` is a `Date` — the helper now converts it, and only emits keys the caller actually set (required under `exactOptionalPropertyTypes`).

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run validate` passes (lint warnings unrelated to this change, pre-existing on `main`)
- [x] `npm run smoke` against a real CalDAV server with a recurrence rule (the `until` → `Date` change is the only behavior change in this PR; existing smoke covers create/list/update/delete but not recurrence)

## Notes
- The `RecurrenceRuleInput` type and `toRecurrenceRule` helper are duplicated between the two tool files. Left as-is to keep this PR scoped; happy to extract in a follow-up if you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)