### PR TITLE
Add support for creating events as wholeDay

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Returns:
 
 ### create-event
 
-Creates an event in the calendar specified by its URL
+Creates an event in the calendar specified by its URL. For a one-day full-day event, set `wholeDay` to true and set `start` and `end` to the same calendar day.
 
 Parameters:
 - `summary`: string
@@ -118,7 +118,7 @@ Returns:
 
 ### update-event
 
-Updates an existing event in the calendar specified by its URL. Only provided fields are changed.
+Updates an existing event in the calendar specified by its URL. Only provided fields are changed. For a one-day full-day event, set `wholeDay` to true and set `start` and `end` to the same calendar day.
 
 Parameters:
 - `uid`: string — Unique identifier of the event to update (obtained from list-events)

--- a/README.md
+++ b/README.md
@@ -94,14 +94,14 @@ Returns:
 
 ### create-event
 
-Creates an event in the calendar specified by its URL. For a one-day full-day event, set `wholeDay` to true and set `start` and `end` to the same calendar day.
+Creates an event in the calendar specified by its URL. For all-day events, set `wholeDay` to true. For a single-day all-day event, use `start` and `end` datetimes on the same calendar date; they do not need to be identical timestamps.
 
 Parameters:
 - `summary`: string
 - `start`: string — Start datetime (ISO 8601)
 - `end`: string — End datetime (ISO 8601)
-- `calendarUrl`: string
 - `wholeDay`: boolean (optional) — Create as a whole-day event
+- `calendarUrl`: string
 - `description`: string (optional)
 - `location`: string (optional)
 - `recurrenceRule`: object (optional)

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Parameters:
 - `start`: string — Start datetime (ISO 8601)
 - `end`: string — End datetime (ISO 8601)
 - `calendarUrl`: string
+- `wholeDay`: boolean (optional) — Create as a whole-day event
 - `description`: string (optional)
 - `location`: string (optional)
 - `recurrenceRule`: object (optional)
@@ -125,6 +126,7 @@ Parameters:
 - `summary`: string (optional)
 - `start`: string (optional)
 - `end`: string (optional)
+- `wholeDay`: boolean (optional) — Update whether this is a whole-day event
 - `description`: string (optional)
 - `location`: string (optional)
 - `recurrenceRule`: object (optional)

--- a/scripts/gen-tool-docs.ts
+++ b/scripts/gen-tool-docs.ts
@@ -40,8 +40,11 @@ function unwrapOptional(schema: z.ZodTypeAny): {
 }
 
 function describeType(schema: z.ZodTypeAny): string {
-	if (schema instanceof z.ZodEffects) {
-		return describeType(schema._def.schema as z.ZodTypeAny);
+	const ZodEffects = (z as typeof z & { ZodEffects?: unknown }).ZodEffects;
+	if (typeof ZodEffects === "function" && schema instanceof ZodEffects) {
+		const inner = (schema as z.ZodTypeAny & { _def: { schema: z.ZodTypeAny } })
+			._def.schema;
+		return describeType(inner);
 	}
 	if (schema instanceof z.ZodString) return "string";
 	if (schema instanceof z.ZodNumber) return "number";

--- a/scripts/gen-tool-docs.ts
+++ b/scripts/gen-tool-docs.ts
@@ -40,12 +40,6 @@ function unwrapOptional(schema: z.ZodTypeAny): {
 }
 
 function describeType(schema: z.ZodTypeAny): string {
-	const ZodEffects = (z as typeof z & { ZodEffects?: unknown }).ZodEffects;
-	if (typeof ZodEffects === "function" && schema instanceof ZodEffects) {
-		const inner = (schema as z.ZodTypeAny & { _def: { schema: z.ZodTypeAny } })
-			._def.schema;
-		return describeType(inner);
-	}
 	if (schema instanceof z.ZodString) return "string";
 	if (schema instanceof z.ZodNumber) return "number";
 	if (schema instanceof z.ZodBoolean) return "boolean";

--- a/scripts/gen-tool-docs.ts
+++ b/scripts/gen-tool-docs.ts
@@ -40,6 +40,9 @@ function unwrapOptional(schema: z.ZodTypeAny): {
 }
 
 function describeType(schema: z.ZodTypeAny): string {
+	if (schema instanceof z.ZodEffects) {
+		return describeType(schema._def.schema as z.ZodTypeAny);
+	}
 	if (schema instanceof z.ZodString) return "string";
 	if (schema instanceof z.ZodNumber) return "number";
 	if (schema instanceof z.ZodBoolean) return "boolean";

--- a/src/tools/create-event.test.ts
+++ b/src/tools/create-event.test.ts
@@ -82,7 +82,7 @@ describe("registerCreateEvent", () => {
 		expect(passed?.recurrenceRule).toBeUndefined();
 	});
 
-	test("passes wholeDay flag when provided", async () => {
+	test("passes wholeDay flag when true", async () => {
 		const mockClient = {
 			createEvent: vi.fn().mockResolvedValue({ uid: "event-123" }),
 		};
@@ -102,5 +102,48 @@ describe("registerCreateEvent", () => {
 
 		const passed = mockClient.createEvent.mock.calls[0]?.[1];
 		expect(passed?.wholeDay).toBe(true);
+	});
+
+	test("passes wholeDay flag when false", async () => {
+		const mockClient = {
+			createEvent: vi.fn().mockResolvedValue({ uid: "event-123" }),
+		};
+
+		const { server, getHandler } = makeServer();
+		registerCreateEvent(mockClient as unknown as CalDAVClient, server);
+		const handler = getHandler();
+		if (!handler) throw new Error("handler not registered");
+
+		await handler({
+			summary: "Timed event",
+			start: "2026-05-12T10:00:00.000Z",
+			end: "2026-05-12T10:30:00.000Z",
+			calendarUrl: "/f/test-calendar/",
+			wholeDay: false,
+		});
+
+		const passed = mockClient.createEvent.mock.calls[0]?.[1];
+		expect(passed?.wholeDay).toBe(false);
+	});
+
+	test("omits wholeDay when not provided", async () => {
+		const mockClient = {
+			createEvent: vi.fn().mockResolvedValue({ uid: "event-123" }),
+		};
+
+		const { server, getHandler } = makeServer();
+		registerCreateEvent(mockClient as unknown as CalDAVClient, server);
+		const handler = getHandler();
+		if (!handler) throw new Error("handler not registered");
+
+		await handler({
+			summary: "Timed event",
+			start: "2026-05-12T10:00:00.000Z",
+			end: "2026-05-12T10:30:00.000Z",
+			calendarUrl: "/f/test-calendar/",
+		});
+
+		const passed = mockClient.createEvent.mock.calls[0]?.[1];
+		expect(passed).not.toHaveProperty("wholeDay");
 	});
 });

--- a/src/tools/create-event.test.ts
+++ b/src/tools/create-event.test.ts
@@ -8,6 +8,7 @@ type ToolHandler = (params: {
 	start: string;
 	end: string;
 	calendarUrl: string;
+	wholeDay?: boolean;
 	description?: string;
 	location?: string;
 	recurrenceRule?: {
@@ -79,5 +80,27 @@ describe("registerCreateEvent", () => {
 
 		const passed = mockClient.createEvent.mock.calls[0]?.[1];
 		expect(passed?.recurrenceRule).toBeUndefined();
+	});
+
+	test("passes wholeDay flag when provided", async () => {
+		const mockClient = {
+			createEvent: vi.fn().mockResolvedValue({ uid: "event-123" }),
+		};
+
+		const { server, getHandler } = makeServer();
+		registerCreateEvent(mockClient as unknown as CalDAVClient, server);
+		const handler = getHandler();
+		if (!handler) throw new Error("handler not registered");
+
+		await handler({
+			summary: "Whole day",
+			start: "2026-05-12T00:00:00.000Z",
+			end: "2026-05-13T00:00:00.000Z",
+			calendarUrl: "/f/test-calendar/",
+			wholeDay: true,
+		});
+
+		const passed = mockClient.createEvent.mock.calls[0]?.[1];
+		expect(passed?.wholeDay).toBe(true);
 	});
 });

--- a/src/tools/create-event.ts
+++ b/src/tools/create-event.ts
@@ -16,8 +16,8 @@ type CreateEventInput = {
 	summary: string;
 	start: string;
 	end: string;
-	calendarUrl: string;
 	wholeDay?: boolean | undefined;
+	calendarUrl: string;
 	description?: string | undefined;
 	location?: string | undefined;
 	recurrenceRule?: RecurrenceRuleInput | undefined;
@@ -48,7 +48,7 @@ const recurrenceRuleSchema = z.object({
 export const createEventDefinition = {
 	name: "create-event",
 	description:
-		"Creates an event in the calendar specified by its URL. For a one-day full-day event, set `wholeDay` to true and set `start` and `end` to the same calendar day.",
+		"Creates an event in the calendar specified by its URL. For all-day events, set `wholeDay` to true. For a single-day all-day event, use `start` and `end` datetimes on the same calendar date; they do not need to be identical timestamps.",
 	inputSchema: {
 		summary: z.string(),
 		start: z
@@ -59,8 +59,8 @@ export const createEventDefinition = {
 			.string()
 			.datetime({ offset: true })
 			.describe("End datetime (ISO 8601)"),
-		calendarUrl: z.string(),
 		wholeDay: z.boolean().optional().describe("Create as a whole-day event"),
+		calendarUrl: z.string(),
 		description: z.string().optional(),
 		location: z.string().optional(),
 		recurrenceRule: recurrenceRuleSchema.optional(),

--- a/src/tools/create-event.ts
+++ b/src/tools/create-event.ts
@@ -17,6 +17,7 @@ type CreateEventInput = {
 	start: string;
 	end: string;
 	calendarUrl: string;
+	wholeDay?: boolean | undefined;
 	description?: string | undefined;
 	location?: string | undefined;
 	recurrenceRule?: RecurrenceRuleInput | undefined;
@@ -58,6 +59,7 @@ export const createEventDefinition = {
 			.datetime({ offset: true })
 			.describe("End datetime (ISO 8601)"),
 		calendarUrl: z.string(),
+		wholeDay: z.boolean().optional().describe("Create as a whole-day event"),
 		description: z.string().optional(),
 		location: z.string().optional(),
 		recurrenceRule: recurrenceRuleSchema.optional(),
@@ -78,6 +80,7 @@ export function registerCreateEvent(client: CalDAVClient, server: McpServer) {
 				summary,
 				start,
 				end,
+				wholeDay,
 				description,
 				location,
 				recurrenceRule,
@@ -86,6 +89,7 @@ export function registerCreateEvent(client: CalDAVClient, server: McpServer) {
 				summary: summary,
 				start: new Date(start),
 				end: new Date(end),
+				...(wholeDay !== undefined && { wholeDay }),
 				...(description !== undefined && { description }),
 				...(location !== undefined && { location }),
 				...(recurrenceRule !== undefined && {

--- a/src/tools/create-event.ts
+++ b/src/tools/create-event.ts
@@ -47,7 +47,8 @@ const recurrenceRuleSchema = z.object({
 
 export const createEventDefinition = {
 	name: "create-event",
-	description: "Creates an event in the calendar specified by its URL",
+	description:
+		"Creates an event in the calendar specified by its URL. For a one-day full-day event, set `wholeDay` to true and set `start` and `end` to the same calendar day.",
 	inputSchema: {
 		summary: z.string(),
 		start: z

--- a/src/tools/update-event.test.ts
+++ b/src/tools/update-event.test.ts
@@ -9,6 +9,7 @@ type ToolHandler = (params: {
 	summary?: string;
 	start?: string;
 	end?: string;
+	wholeDay?: boolean;
 	description?: string;
 	location?: string;
 	recurrenceRule?: {
@@ -150,5 +151,31 @@ describe("registerUpdateEvent", () => {
 		expect(passed?.recurrenceRule?.until).toBeInstanceOf(Date);
 		expect(passed?.recurrenceRule?.until?.toISOString()).toBe(untilIso);
 		expect(passed?.recurrenceRule?.freq).toBe("DAILY");
+	});
+
+	test("updates wholeDay flag when provided", async () => {
+		const mockClient = {
+			getEventsByHref: vi.fn().mockResolvedValue([existingEvent]),
+			updateEvent: vi.fn().mockResolvedValue({
+				uid: "event-123",
+				href: existingEvent.href,
+				etag: '"new-etag"',
+				newCtag: "",
+			}),
+		};
+
+		const { server, getHandler } = makeServer();
+		registerUpdateEvent(mockClient as unknown as CalDAVClient, server);
+		const handler = getHandler();
+		if (!handler) throw new Error("handler not registered");
+
+		await handler({
+			uid: "event-123",
+			calendarUrl: "/f/test-calendar/",
+			wholeDay: true,
+		});
+
+		const passed = mockClient.updateEvent.mock.calls[0]?.[1];
+		expect(passed?.wholeDay).toBe(true);
 	});
 });

--- a/src/tools/update-event.ts
+++ b/src/tools/update-event.ts
@@ -49,7 +49,7 @@ const recurrenceRuleSchema = z.object({
 export const updateEventDefinition = {
 	name: "update-event",
 	description:
-		"Updates an existing event in the calendar specified by its URL. Only provided fields are changed.",
+		"Updates an existing event in the calendar specified by its URL. Only provided fields are changed. For a one-day full-day event, set `wholeDay` to true and set `start` and `end` to the same calendar day.",
 	inputSchema: {
 		uid: z
 			.string()

--- a/src/tools/update-event.ts
+++ b/src/tools/update-event.ts
@@ -18,6 +18,7 @@ type UpdateEventInput = {
 	summary?: string | undefined;
 	start?: string | undefined;
 	end?: string | undefined;
+	wholeDay?: boolean | undefined;
 	description?: string | undefined;
 	location?: string | undefined;
 	recurrenceRule?: RecurrenceRuleInput | undefined;
@@ -59,6 +60,10 @@ export const updateEventDefinition = {
 		summary: z.string().optional(),
 		start: z.string().datetime({ offset: true }).optional(),
 		end: z.string().datetime({ offset: true }).optional(),
+		wholeDay: z
+			.boolean()
+			.optional()
+			.describe("Update whether this is a whole-day event"),
 		description: z.string().optional(),
 		location: z.string().optional(),
 		recurrenceRule: recurrenceRuleSchema.optional(),
@@ -80,6 +85,7 @@ export function registerUpdateEvent(client: CalDAVClient, server: McpServer) {
 				summary,
 				start,
 				end,
+				wholeDay,
 				description,
 				location,
 				recurrenceRule,
@@ -98,6 +104,7 @@ export function registerUpdateEvent(client: CalDAVClient, server: McpServer) {
 				...(summary !== undefined && { summary }),
 				...(start !== undefined && { start: new Date(start) }),
 				...(end !== undefined && { end: new Date(end) }),
+				...(wholeDay !== undefined && { wholeDay }),
 				...(description !== undefined && { description }),
 				...(location !== undefined && { location }),
 				...(recurrenceRule !== undefined && {


### PR DESCRIPTION
This MCP is currently unable to create whole-day events. ts-caldav already supports this, so this PR exposes a new `wholeDay` option to mark events as whole day