### PR TITLE
feat: publish to MCP Registry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,3 +140,14 @@ jobs:
       - run: npx semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set version in server.json
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          jq --arg v "$VERSION" '.packages[0].version = $v | .version = $v' server.json > server.tmp && mv server.tmp server.json
+      - name: Install mcp-publisher
+        run: |
+          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz" | tar xz mcp-publisher
+      - name: Publish to MCP Registry
+        run: |
+          ./mcp-publisher login github-oidc
+          ./mcp-publisher publish

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
 	"name": "caldav-mcp",
+	"mcpName": "io.github.dominik1001/caldav-mcp",
 	"description": "A CalDAV client using Model Context Protocol (MCP) to expose calendar operations as tools for AI assistants.",
 	"version": "0.8.0",
 	"main": "dist/index.js",

--- a/server.json
+++ b/server.json
@@ -1,0 +1,43 @@
+{
+	"$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+	"name": "io.github.dominik1001/caldav-mcp",
+	"description": "CalDAV calendar operations (list, create, update, delete events) as MCP tools.",
+	"repository": {
+		"url": "https://github.com/dominik1001/caldav-mcp",
+		"source": "github"
+	},
+	"version": "0.8.0",
+	"packages": [
+		{
+			"registryType": "npm",
+			"identifier": "caldav-mcp",
+			"version": "0.8.0",
+			"transport": {
+				"type": "stdio"
+			},
+			"environmentVariables": [
+				{
+					"name": "CALDAV_BASE_URL",
+					"description": "Base URL of the CalDAV server (e.g. https://caldav.example.com)",
+					"isRequired": true,
+					"format": "string",
+					"isSecret": false
+				},
+				{
+					"name": "CALDAV_USERNAME",
+					"description": "Username for CalDAV authentication",
+					"isRequired": true,
+					"format": "string",
+					"isSecret": false
+				},
+				{
+					"name": "CALDAV_PASSWORD",
+					"description": "Password for CalDAV authentication",
+					"isRequired": true,
+					"format": "string",
+					"isSecret": true
+				}
+			]
+		}
+	]
+}


### PR DESCRIPTION
## Summary
- Add `mcpName` ownership marker to `package.json` for registry verification
- Add `server.json` with registry metadata (description, npm package, env vars)
- Extend CI release workflow to automatically publish to the MCP Registry via GitHub OIDC auth after each semantic-release

## How it works
On every release, after `semantic-release` publishes to npm, the workflow:
1. Injects the current version into `server.json`
2. Downloads `mcp-publisher` from the registry repo
3. Authenticates via GitHub OIDC (no secrets needed) and publishes

## Test plan
- [x] `npm run validate` passes
- [x] `mcp-publisher validate` passes locally
- [ ] CI release workflow publishes to the MCP Registry on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)