### PR TITLE
fix(ci): CI workflow fixes

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,12 +12,7 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   claude-review:
+    # Skip fork PRs — OIDC auth unavailable. Remove once anthropics/claude-code-action#939 lands.
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary
- Move MCP Registry publish to a separate workflow triggered by `release: published` (fixes duplicate version error on non-release merges)
- Grant `pull-requests: write` to Claude Code Review (fixes silent review failures)
- Skip Claude Code Review on fork PRs (OIDC auth unavailable, tracking anthropics/claude-code-action#939)

## Test plan
- [x] `npm run validate` passes
- [ ] Non-release merges no longer fail the release job
- [ ] Claude Code Review posts inline comments on same-repo PRs
- [ ] Fork PRs skip the review job cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)