### PR TITLE
Skip Claude code review for Dependabot PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -13,7 +13,10 @@ on:
 jobs:
   claude-review:
     # Skip fork PRs — OIDC auth unavailable. Remove once anthropics/claude-code-action#939 lands.
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    # Skip Dependabot PRs — automated dependency bumps don't need a code review.
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
Updated the Claude code review workflow to skip automated Dependabot PRs, since dependency version bumps don't require manual code review.

## Changes
- Extended the `claude-review` job condition to exclude PRs from `dependabot[bot]`
- Maintains existing fork PR skip logic while adding the new Dependabot filter

## Details
The workflow now checks both:
1. That the PR is not from a fork (existing OIDC auth requirement)
2. That the PR author is not `dependabot[bot]` (new filter)

This reduces unnecessary Claude review invocations for routine dependency updates while preserving reviews for user-authored and other automated changes.

https://claude.ai/code/session_01QYKpnbLUNwJjCZnUgqxr8b