### PR TITLE
fix: preserve calendar date for whole-day events with non-UTC offsets

### DIFF
--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -183,6 +183,67 @@ async function main() {
 	);
 	log("deleted recurring event");
 
+	// Whole-day event round trip with a non-UTC offset input. Regression test
+	// for a bug where `new Date(iso)` + downstream UTC-truncation shifted the
+	// stored calendar date back by one day for any offset east of UTC — see
+	// toWholeDayDate() in src/tools/whole-day-date.ts and its unit tests for
+	// the conversion logic; here we verify the fix holds through ts-caldav's
+	// real serialization and a real CalDAV server's storage/parsing.
+	const wholeDayDate = new Date(Date.now() + 3 * 24 * 60 * 60 * 1000);
+	const wholeDayDateStr = wholeDayDate.toISOString().slice(0, 10);
+	const wholeDayIso = `${wholeDayDateStr}T00:00:00+09:00`;
+	const wholeDaySummary = `caldav-mcp smoke whole-day ${wholeDayDateStr}`;
+	const wholeDayUid = unwrapText(
+		await client.callTool({
+			name: "create-event",
+			arguments: {
+				summary: wholeDaySummary,
+				start: wholeDayIso,
+				end: wholeDayIso,
+				wholeDay: true,
+				calendarUrl,
+			},
+		}),
+	);
+	log("created whole-day event", { uid: wholeDayUid, input: wholeDayIso });
+
+	const wholeDayWindowStart = new Date(
+		wholeDayDate.getTime() - 24 * 60 * 60 * 1000,
+	);
+	const wholeDayWindowEnd = new Date(
+		wholeDayDate.getTime() + 2 * 24 * 60 * 60 * 1000,
+	);
+	const wholeDayListed = JSON.parse(
+		unwrapText(
+			await client.callTool({
+				name: "list-events",
+				arguments: {
+					start: wholeDayWindowStart.toISOString(),
+					end: wholeDayWindowEnd.toISOString(),
+					calendarUrl,
+				},
+			}),
+		),
+	) as Array<{ uid: string; start: string }>;
+	const foundWholeDay = wholeDayListed.find((e) => e.uid === wholeDayUid);
+	if (!foundWholeDay)
+		throw new Error(`Created whole-day event ${wholeDayUid} not found`);
+	const storedDateStr = foundWholeDay.start.slice(0, 10);
+	if (storedDateStr !== wholeDayDateStr) {
+		throw new Error(
+			`Whole-day event date shifted: expected ${wholeDayDateStr}, got ${storedDateStr} (input ${wholeDayIso})`,
+		);
+	}
+	log("verified whole-day event date", storedDateStr);
+
+	unwrapText(
+		await client.callTool({
+			name: "delete-event",
+			arguments: { uid: wholeDayUid, calendarUrl },
+		}),
+	);
+	log("deleted whole-day event");
+
 	// VTODO round-trip: create → list → complete → update → delete on a
 	// task-capable collection. Tasks often live in a separate VTODO calendar;
 	// if the account has none, skip rather than fail (events already verified).

--- a/src/tools/create-event.test.ts
+++ b/src/tools/create-event.test.ts
@@ -126,6 +126,36 @@ describe("registerCreateEvent", () => {
 		expect(passed?.wholeDay).toBe(false);
 	});
 
+	test("preserves the calendar date for whole-day events with a positive UTC offset", async () => {
+		const mockClient = {
+			createEvent: vi.fn().mockResolvedValue({ uid: "event-123" }),
+		};
+
+		const { server, getHandler } = makeServer();
+		registerCreateEvent(mockClient as unknown as CalDAVClient, server);
+		const handler = getHandler();
+		if (!handler) throw new Error("handler not registered");
+
+		await handler({
+			summary: "Quarterly reminder",
+			start: "2026-09-30T00:00:00+09:00",
+			end: "2026-09-30T00:00:00+09:00",
+			calendarUrl: "/f/test-calendar/",
+			wholeDay: true,
+			recurrenceRule: {
+				freq: "YEARLY",
+				until: "2030-09-30T00:00:00+09:00",
+			},
+		});
+
+		const passed = mockClient.createEvent.mock.calls[0]?.[1];
+		expect(passed?.start.toISOString()).toBe("2026-09-30T00:00:00.000Z");
+		expect(passed?.end.toISOString()).toBe("2026-09-30T00:00:00.000Z");
+		expect(passed?.recurrenceRule?.until.toISOString()).toBe(
+			"2030-09-30T00:00:00.000Z",
+		);
+	});
+
 	test("omits wholeDay when not provided", async () => {
 		const mockClient = {
 			createEvent: vi.fn().mockResolvedValue({ uid: "event-123" }),

--- a/src/tools/create-event.ts
+++ b/src/tools/create-event.ts
@@ -1,6 +1,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { CalDAVClient, RecurrenceRule } from "ts-caldav";
 import { z } from "zod";
+import { toWholeDayDate } from "./whole-day-date.js";
 
 type RecurrenceRuleInput = {
 	freq?: "DAILY" | "WEEKLY" | "MONTHLY" | "YEARLY" | undefined;
@@ -23,12 +24,17 @@ type CreateEventInput = {
 	recurrenceRule?: RecurrenceRuleInput | undefined;
 };
 
-function toRecurrenceRule(r: RecurrenceRuleInput): RecurrenceRule {
+function toRecurrenceRule(
+	r: RecurrenceRuleInput,
+	wholeDay?: boolean,
+): RecurrenceRule {
 	const out: RecurrenceRule = {};
 	if (r.freq !== undefined) out.freq = r.freq;
 	if (r.interval !== undefined) out.interval = r.interval;
 	if (r.count !== undefined) out.count = r.count;
-	if (r.until !== undefined) out.until = new Date(r.until);
+	if (r.until !== undefined) {
+		out.until = wholeDay ? toWholeDayDate(r.until) : new Date(r.until);
+	}
 	if (r.byday !== undefined) out.byday = r.byday;
 	if (r.bymonthday !== undefined) out.bymonthday = r.bymonthday;
 	if (r.bymonth !== undefined) out.bymonth = r.bymonth;
@@ -88,13 +94,13 @@ export function registerCreateEvent(client: CalDAVClient, server: McpServer) {
 			} = args;
 			const event = await client.createEvent(calendarUrl, {
 				summary: summary,
-				start: new Date(start),
-				end: new Date(end),
+				start: wholeDay ? toWholeDayDate(start) : new Date(start),
+				end: wholeDay ? toWholeDayDate(end) : new Date(end),
 				...(wholeDay !== undefined && { wholeDay }),
 				...(description !== undefined && { description }),
 				...(location !== undefined && { location }),
 				...(recurrenceRule !== undefined && {
-					recurrenceRule: toRecurrenceRule(recurrenceRule),
+					recurrenceRule: toRecurrenceRule(recurrenceRule, wholeDay),
 				}),
 			});
 

--- a/src/tools/update-event.test.ts
+++ b/src/tools/update-event.test.ts
@@ -181,4 +181,65 @@ describe("registerUpdateEvent", () => {
 		const passed = mockClient.updateEvent.mock.calls[0]?.[1];
 		expect(passed?.wholeDay).toBe(true);
 	});
+
+	test("preserves the calendar date when updating a whole-day event with a positive UTC offset", async () => {
+		const mockClient = {
+			getEventsByHref: vi.fn().mockResolvedValue([existingEvent]),
+			updateEvent: vi.fn().mockResolvedValue({
+				uid: "event-123",
+				href: existingEvent.href,
+				etag: '"new-etag"',
+				newCtag: "",
+			}),
+		};
+
+		const { server, getHandler } = makeServer();
+		registerUpdateEvent(mockClient as unknown as CalDAVClient, server);
+		const handler = getHandler();
+		if (!handler) throw new Error("handler not registered");
+
+		await handler({
+			uid: "event-123",
+			calendarUrl: "/f/test-calendar/",
+			wholeDay: true,
+			start: "2026-09-30T00:00:00+09:00",
+			end: "2026-09-30T00:00:00+09:00",
+		});
+
+		const passed = mockClient.updateEvent.mock.calls[0]?.[1];
+		expect(passed?.start.toISOString()).toBe("2026-09-30T00:00:00.000Z");
+		expect(passed?.end.toISOString()).toBe("2026-09-30T00:00:00.000Z");
+	});
+
+	test("keeps treating start/end as whole-day when wholeDay isn't passed but the existing event is whole-day", async () => {
+		const existingWholeDayEvent: Event = {
+			...existingEvent,
+			wholeDay: true,
+		};
+		const mockClient = {
+			getEventsByHref: vi.fn().mockResolvedValue([existingWholeDayEvent]),
+			updateEvent: vi.fn().mockResolvedValue({
+				uid: "event-123",
+				href: existingEvent.href,
+				etag: '"new-etag"',
+				newCtag: "",
+			}),
+		};
+
+		const { server, getHandler } = makeServer();
+		registerUpdateEvent(mockClient as unknown as CalDAVClient, server);
+		const handler = getHandler();
+		if (!handler) throw new Error("handler not registered");
+
+		await handler({
+			uid: "event-123",
+			calendarUrl: "/f/test-calendar/",
+			start: "2026-09-30T00:00:00+09:00",
+			end: "2026-09-30T00:00:00+09:00",
+		});
+
+		const passed = mockClient.updateEvent.mock.calls[0]?.[1];
+		expect(passed?.start.toISOString()).toBe("2026-09-30T00:00:00.000Z");
+		expect(passed?.end.toISOString()).toBe("2026-09-30T00:00:00.000Z");
+	});
 });

--- a/src/tools/update-event.ts
+++ b/src/tools/update-event.ts
@@ -2,6 +2,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { CalDAVClient, RecurrenceRule } from "ts-caldav";
 import { z } from "zod";
 import { hrefFor } from "./caldav-href.js";
+import { toWholeDayDate } from "./whole-day-date.js";
 
 type RecurrenceRuleInput = {
 	freq?: "DAILY" | "WEEKLY" | "MONTHLY" | "YEARLY" | undefined;
@@ -25,12 +26,17 @@ type UpdateEventInput = {
 	recurrenceRule?: RecurrenceRuleInput | undefined;
 };
 
-function toRecurrenceRule(r: RecurrenceRuleInput): RecurrenceRule {
+function toRecurrenceRule(
+	r: RecurrenceRuleInput,
+	wholeDay?: boolean,
+): RecurrenceRule {
 	const out: RecurrenceRule = {};
 	if (r.freq !== undefined) out.freq = r.freq;
 	if (r.interval !== undefined) out.interval = r.interval;
 	if (r.count !== undefined) out.count = r.count;
-	if (r.until !== undefined) out.until = new Date(r.until);
+	if (r.until !== undefined) {
+		out.until = wholeDay ? toWholeDayDate(r.until) : new Date(r.until);
+	}
 	if (r.byday !== undefined) out.byday = r.byday;
 	if (r.bymonthday !== undefined) out.bymonthday = r.bymonthday;
 	if (r.bymonth !== undefined) out.bymonth = r.bymonth;
@@ -99,16 +105,23 @@ export function registerUpdateEvent(client: CalDAVClient, server: McpServer) {
 				throw new Error(`Event not found: ${uid}`);
 			}
 
+			const effectiveWholeDay =
+				wholeDay !== undefined ? wholeDay : existing.wholeDay;
+
 			const updated = await client.updateEvent(calendarUrl, {
 				...existing,
 				...(summary !== undefined && { summary }),
-				...(start !== undefined && { start: new Date(start) }),
-				...(end !== undefined && { end: new Date(end) }),
+				...(start !== undefined && {
+					start: effectiveWholeDay ? toWholeDayDate(start) : new Date(start),
+				}),
+				...(end !== undefined && {
+					end: effectiveWholeDay ? toWholeDayDate(end) : new Date(end),
+				}),
 				...(wholeDay !== undefined && { wholeDay }),
 				...(description !== undefined && { description }),
 				...(location !== undefined && { location }),
 				...(recurrenceRule !== undefined && {
-					recurrenceRule: toRecurrenceRule(recurrenceRule),
+					recurrenceRule: toRecurrenceRule(recurrenceRule, effectiveWholeDay),
 				}),
 			});
 

--- a/src/tools/whole-day-date.test.ts
+++ b/src/tools/whole-day-date.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "vitest";
+import { toWholeDayDate } from "./whole-day-date.js";
+
+describe("toWholeDayDate", () => {
+	test("keeps the calendar date for a UTC input", () => {
+		expect(toWholeDayDate("2026-09-30T00:00:00.000Z").toISOString()).toBe(
+			"2026-09-30T00:00:00.000Z",
+		);
+	});
+
+	test("keeps the calendar date for a positive offset (Asia/Seoul, +09:00)", () => {
+		expect(toWholeDayDate("2026-09-30T00:00:00+09:00").toISOString()).toBe(
+			"2026-09-30T00:00:00.000Z",
+		);
+	});
+
+	test("keeps the calendar date for a negative offset (-07:00)", () => {
+		expect(toWholeDayDate("2026-09-30T00:00:00-07:00").toISOString()).toBe(
+			"2026-09-30T00:00:00.000Z",
+		);
+	});
+
+	test("keeps the calendar date at a month boundary (Sep 30)", () => {
+		expect(toWholeDayDate("2026-09-30T00:00:00+09:00").toISOString()).toBe(
+			"2026-09-30T00:00:00.000Z",
+		);
+	});
+
+	test("keeps the calendar date at a month boundary (Jan 31)", () => {
+		expect(toWholeDayDate("2027-01-31T00:00:00+09:00").toISOString()).toBe(
+			"2027-01-31T00:00:00.000Z",
+		);
+	});
+
+	test("keeps the calendar date on a leap day (Feb 29)", () => {
+		expect(toWholeDayDate("2028-02-29T00:00:00+09:00").toISOString()).toBe(
+			"2028-02-29T00:00:00.000Z",
+		);
+	});
+});

--- a/src/tools/whole-day-date.ts
+++ b/src/tools/whole-day-date.ts
@@ -1,0 +1,17 @@
+/**
+ * Converts an ISO 8601 datetime string to a `Date` representing the same
+ * calendar date at UTC midnight, for use with whole-day events.
+ *
+ * ts-caldav derives the `VALUE=DATE` it writes to the server by calling
+ * `date.toISOString().split("T")[0]` on the `Date` it's given. A `Date`
+ * built with `new Date(iso)` preserves the input's UTC *instant*, not its
+ * local calendar date — so for any offset east of UTC, that truncation
+ * silently rolls the stored date back by one day (e.g. local midnight
+ * `2026-09-30T00:00:00+09:00` becomes `2026-09-29T15:00:00.000Z`, which
+ * truncates to `2026-09-29`). Anchoring the date at UTC midnight instead
+ * makes the truncation a no-op, so the calendar date the caller wrote is
+ * the calendar date that gets stored.
+ */
+export function toWholeDayDate(iso: string): Date {
+	return new Date(`${iso.slice(0, 10)}T00:00:00.000Z`);
+}


### PR DESCRIPTION
## Summary

Whole-day events created (or updated) with a local-midnight ISO datetime at a positive UTC offset (e.g. `2026-09-30T00:00:00+09:00`) were stored one calendar day early on the server.

## Root cause

`new Date(iso)` preserves the input's UTC *instant*, not its local calendar date. `ts-caldav` then derives the stored `VALUE=DATE` (for `DTSTART`/`DTEND`/`RRULE UNTIL` on whole-day events) via `date.toISOString().split("T")[0]`. For any offset east of UTC, that truncation silently rolls the calendar date back by one day — e.g. `2026-09-30T00:00:00+09:00` becomes the UTC instant `2026-09-29T15:00:00.000Z`, which truncates to `2026-09-29`.

## Fix

Added `toWholeDayDate()` (`src/tools/whole-day-date.ts`), which takes the calendar date directly from the ISO input string and anchors it at UTC midnight, so `ts-caldav`'s later `toISOString()` truncation is a no-op. `create-event` and `update-event` now use it for `start`/`end`/`recurrenceRule.until` whenever the event is (or is being updated to be, or already is) whole-day. `update-event` falls back to the existing event's `wholeDay` flag when the caller doesn't pass one explicitly, so partial updates (e.g. just changing `start`) on an existing whole-day event stay date-correct too.

## Test plan

- [x] `npm run validate` (check + test + knip + docs:check + build) passes locally
- [x] New unit tests in `whole-day-date.test.ts` cover UTC, `+09:00`, `-07:00`, month-end (Jan 31, Sep 30), and leap day (Feb 29) inputs
- [x] New regression tests in `create-event.test.ts` / `update-event.test.ts` reproduce the exact scenario from the issue (Asia/Seoul `+09:00`, including `recurrenceRule.until`) and assert the stored date is unchanged
- [x] Added a whole-day event case to `scripts/smoke.ts` (create → list → delete with a `+09:00` input) so the fix is also verified end-to-end against a real CalDAV server, since the unit tests mock the client and don't exercise `ts-caldav`'s actual serialization or a real server's storage/parsing. Not run here (no live CalDAV server in this environment) — needs `npm run smoke` against a real server to confirm.

Fixes #89