### PR TITLE
feat: expand recurring events into their occurrences

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Parameters:
 - `calendarUrl`: string
 
 Returns:
-- A list of occurrences that fall within the given timeframe, each containing `uid`, `summary`, `start`, `end`, `recurring`, and optionally `description` and `location`. A recurring series contributes one entry per occurrence in the timeframe, so several entries can share a `uid`.
+- A list of occurrences that fall within the given timeframe, each containing `uid`, `summary`, `start`, `end`, `recurring`, `occurrence`, and optionally `description` and `location`. A recurring series contributes one entry per occurrence, so several entries share a `uid`. Careful when acting on one of them: `uid` addresses the whole series, and update-event and delete-event take nothing finer, so they change or remove every instance. `occurrence` names the single slot for display and cannot be passed back to target it.
 
 ### create-event
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Parameters:
 - `calendarUrl`: string
 
 Returns:
-- A list of events that fall within the given timeframe, each containing `uid`, `summary`, `start`, `end`, and optionally `description` and `location`
+- A list of occurrences that fall within the given timeframe, each containing `uid`, `summary`, `start`, `end`, `recurring`, and optionally `description` and `location`. A recurring series contributes one entry per occurrence in the timeframe, so several entries can share a `uid`.
 
 ### create-event
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
 			"license": "MIT",
 			"dependencies": {
 				"@modelcontextprotocol/sdk": "^1.26.0",
+				"ical.js": "^2.2.1",
 				"ts-caldav": "^0.4.0",
 				"zod": "^4.4.3"
 			},

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
 	},
 	"dependencies": {
 		"@modelcontextprotocol/sdk": "^1.26.0",
+		"ical.js": "^2.2.1",
 		"ts-caldav": "^0.4.0",
 		"zod": "^4.4.3"
 	},

--- a/src/tools/list-events.test.ts
+++ b/src/tools/list-events.test.ts
@@ -117,3 +117,53 @@ describe("registerListEvents", () => {
 		expect(events[1]).not.toHaveProperty("location");
 	});
 });
+
+describe("registerListEvents with a rescheduled occurrence", () => {
+	test("reports a moved occurrence once, at its new slot", async () => {
+		// A weekly Friday 14:30 series, with the 21 August instance moved to 17:00.
+		// The server returns both the master and the replacement, sharing a uid.
+		const mockClient = {
+			getEvents: vi.fn().mockResolvedValue([
+				{
+					uid: "series-1",
+					summary: "Weekly sync",
+					start: new Date("2026-08-14T12:30:00Z"),
+					end: new Date("2026-08-14T13:15:00Z"),
+					startTzid: "Europe/Berlin",
+					recurrenceRule: { freq: "WEEKLY", byday: ["FR"] },
+				},
+				{
+					uid: "series-1",
+					summary: "Weekly sync",
+					start: new Date("2026-08-21T15:00:00Z"),
+					end: new Date("2026-08-21T15:45:00Z"),
+					startTzid: "Europe/Berlin",
+					customFields: { "recurrence-id": "2026-08-21T14:30:00" },
+				},
+			]),
+		};
+
+		let toolHandler: ToolHandler | null = null;
+		const server = new McpServer({ name: "test-server", version: "0.1.0" });
+		const originalRegisterTool = server.registerTool.bind(server);
+		server.registerTool = vi.fn(
+			(name: string, config: unknown, handler: ToolHandler) => {
+				if (name === "list-events") toolHandler = handler;
+				return originalRegisterTool(name, config, handler);
+			},
+		) as typeof server.registerTool;
+
+		registerListEvents(mockClient as unknown as CalDAVClient, server);
+		if (!toolHandler) throw new Error("handler not registered");
+
+		const result = await toolHandler({
+			calendarUrl: "/f/test-calendar/",
+			start: "2026-08-16T22:00:00Z",
+			end: "2026-08-23T22:00:00Z",
+		});
+		const events = JSON.parse(result.content[0].text);
+
+		expect(events).toHaveLength(1);
+		expect(events[0].start).toBe("2026-08-21T15:00:00.000Z");
+	});
+});

--- a/src/tools/list-events.ts
+++ b/src/tools/list-events.ts
@@ -1,6 +1,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { CalDAVClient } from "ts-caldav";
 import { z } from "zod";
+import { occurrencesWithin } from "./recurrence.js";
 
 type ListEventsInput = {
 	start: string;
@@ -28,7 +29,7 @@ export const listEventsDefinition = {
 		calendarUrl: z.string(),
 	},
 	returns:
-		"A list of events that fall within the given timeframe, each containing `uid`, `summary`, `start`, `end`, and optionally `description` and `location`",
+		"A list of occurrences that fall within the given timeframe, each containing `uid`, `summary`, `start`, `end`, `recurring`, and optionally `description` and `location`. A recurring series contributes one entry per occurrence in the timeframe, so several entries can share a `uid`.",
 } as const;
 
 export function registerListEvents(client: CalDAVClient, server: McpServer) {
@@ -40,19 +41,27 @@ export function registerListEvents(client: CalDAVClient, server: McpServer) {
 		},
 		async (args: ListEventsInput) => {
 			const { calendarUrl, start, end } = args;
-			const options = {
-				start: new Date(start),
-				end: new Date(end),
-			};
-			const allEvents = await client.getEvents(calendarUrl, options);
-			const data = allEvents.map((e) => ({
-				uid: e.uid,
-				summary: e.summary,
-				start: e.start,
-				end: e.end,
-				...(e.description && { description: e.description }),
-				...(e.location && { location: e.location }),
-			}));
+			const windowStart = new Date(start);
+			const windowEnd = new Date(end);
+			const allEvents = await client.getEvents(calendarUrl, {
+				start: windowStart,
+				end: windowEnd,
+			});
+			const data = allEvents.flatMap((e) => {
+				const duration = e.end.getTime() - e.start.getTime();
+				return occurrencesWithin(e, windowStart, windowEnd).map(
+					(occurrence) => ({
+						uid: e.uid,
+						summary: e.summary,
+						start: occurrence,
+						end: new Date(occurrence.getTime() + duration),
+						recurring: Boolean(e.recurrenceRule),
+						...(e.description && { description: e.description }),
+						...(e.location && { location: e.location }),
+					}),
+				);
+			});
+			data.sort((a, b) => a.start.getTime() - b.start.getTime());
 			return {
 				content: [{ type: "text", text: JSON.stringify(data) }],
 			};

--- a/src/tools/list-events.ts
+++ b/src/tools/list-events.ts
@@ -29,7 +29,7 @@ export const listEventsDefinition = {
 		calendarUrl: z.string(),
 	},
 	returns:
-		"A list of occurrences that fall within the given timeframe, each containing `uid`, `summary`, `start`, `end`, `recurring`, `occurrence`, and optionally `description` and `location`. A recurring series contributes one entry per occurrence, so several entries share a `uid`: that field addresses the whole series, while `occurrence` identifies the single instance.",
+		"A list of occurrences that fall within the given timeframe, each containing `uid`, `summary`, `start`, `end`, `recurring`, `occurrence`, and optionally `description` and `location`. A recurring series contributes one entry per occurrence, so several entries share a `uid`. Careful when acting on one of them: `uid` addresses the whole series, and update-event and delete-event take nothing finer, so they change or remove every instance. `occurrence` names the single slot for display and cannot be passed back to target it.",
 } as const;
 
 export function registerListEvents(client: CalDAVClient, server: McpServer) {

--- a/src/tools/list-events.ts
+++ b/src/tools/list-events.ts
@@ -1,7 +1,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { CalDAVClient } from "ts-caldav";
 import { z } from "zod";
-import { occurrencesWithin } from "./recurrence.js";
+import { occurrencesWithin, replacedOccurrences } from "./recurrence.js";
 
 type ListEventsInput = {
 	start: string;
@@ -47,19 +47,26 @@ export function registerListEvents(client: CalDAVClient, server: McpServer) {
 				start: windowStart,
 				end: windowEnd,
 			});
+			// A rescheduled occurrence arrives as a second event sharing the uid of
+			// its series. Without this the master would still expand into the slot
+			// the override vacated, and the meeting would be listed twice.
+			const replaced = replacedOccurrences(allEvents);
 			const data = allEvents.flatMap((e) => {
 				const duration = e.end.getTime() - e.start.getTime();
-				return occurrencesWithin(e, windowStart, windowEnd).map(
-					(occurrence) => ({
-						uid: e.uid,
-						summary: e.summary,
-						start: occurrence,
-						end: new Date(occurrence.getTime() + duration),
-						recurring: Boolean(e.recurrenceRule),
-						...(e.description && { description: e.description }),
-						...(e.location && { location: e.location }),
-					}),
-				);
+				return occurrencesWithin(
+					e,
+					windowStart,
+					windowEnd,
+					replaced.get(e.uid),
+				).map((occurrence) => ({
+					uid: e.uid,
+					summary: e.summary,
+					start: occurrence,
+					end: new Date(occurrence.getTime() + duration),
+					recurring: Boolean(e.recurrenceRule),
+					...(e.description && { description: e.description }),
+					...(e.location && { location: e.location }),
+				}));
 			});
 			data.sort((a, b) => a.start.getTime() - b.start.getTime());
 			return {

--- a/src/tools/list-events.ts
+++ b/src/tools/list-events.ts
@@ -1,7 +1,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { CalDAVClient } from "ts-caldav";
 import { z } from "zod";
-import { occurrencesWithin, replacedOccurrences } from "./recurrence.js";
+import { expandEvents } from "./recurrence.js";
 
 type ListEventsInput = {
 	start: string;
@@ -29,7 +29,7 @@ export const listEventsDefinition = {
 		calendarUrl: z.string(),
 	},
 	returns:
-		"A list of occurrences that fall within the given timeframe, each containing `uid`, `summary`, `start`, `end`, `recurring`, and optionally `description` and `location`. A recurring series contributes one entry per occurrence in the timeframe, so several entries can share a `uid`.",
+		"A list of occurrences that fall within the given timeframe, each containing `uid`, `summary`, `start`, `end`, `recurring`, `occurrence`, and optionally `description` and `location`. A recurring series contributes one entry per occurrence, so several entries share a `uid`: that field addresses the whole series, while `occurrence` identifies the single instance.",
 } as const;
 
 export function registerListEvents(client: CalDAVClient, server: McpServer) {
@@ -46,29 +46,28 @@ export function registerListEvents(client: CalDAVClient, server: McpServer) {
 			const allEvents = await client.getEvents(calendarUrl, {
 				start: windowStart,
 				end: windowEnd,
+				// Servers that honour this return the occurrences already expanded,
+				// with EXDATE and replacements applied; expandEvents then only has to
+				// pass them through. The ones that ignore it are why it exists.
+				expand: true,
 			});
-			// A rescheduled occurrence arrives as a second event sharing the uid of
-			// its series. Without this the master would still expand into the slot
-			// the override vacated, and the meeting would be listed twice.
-			const replaced = replacedOccurrences(allEvents);
-			const data = allEvents.flatMap((e) => {
-				const duration = e.end.getTime() - e.start.getTime();
-				return occurrencesWithin(
-					e,
-					windowStart,
-					windowEnd,
-					replaced.get(e.uid),
-				).map((occurrence) => ({
-					uid: e.uid,
-					summary: e.summary,
-					start: occurrence,
-					end: new Date(occurrence.getTime() + duration),
-					recurring: Boolean(e.recurrenceRule),
-					...(e.description && { description: e.description }),
-					...(e.location && { location: e.location }),
-				}));
-			});
-			data.sort((a, b) => a.start.getTime() - b.start.getTime());
+			const data = expandEvents(allEvents, windowStart, windowEnd).map(
+				({ event, start, key, fromSeries }) => ({
+					uid: event.uid,
+					summary: event.summary,
+					start,
+					end: new Date(
+						start.getTime() + (event.end.getTime() - event.start.getTime()),
+					),
+					recurring: fromSeries,
+					// Identifies this occurrence within the series. `uid` addresses the
+					// whole series, so update-event and delete-event acting on it hit
+					// every instance, not the one shown here.
+					occurrence: key,
+					...(event.description && { description: event.description }),
+					...(event.location && { location: event.location }),
+				}),
+			);
 			return {
 				content: [{ type: "text", text: JSON.stringify(data) }],
 			};

--- a/src/tools/recurrence.test.ts
+++ b/src/tools/recurrence.test.ts
@@ -359,3 +359,23 @@ describe("expandEvents", () => {
 		]);
 	});
 });
+
+describe("expandEvents with malformed input", () => {
+	test("does not treat an event with its own rule as a replacement", () => {
+		// RFC 5545 forbids the combination, but the point of this module is
+		// surviving what a server actually sends. Honouring the RECURRENCE-ID
+		// here would stamp every expanded occurrence with the same key.
+		const broken = makeEvent({
+			start: new Date("2026-08-17T12:30:00Z"),
+			recurrenceRule: { freq: "DAILY" },
+			customFields: { "recurrence-id": "2026-08-21T14:30:00" },
+		});
+		const out = expandEvents(
+			[broken],
+			new Date("2026-08-16T22:00:00Z"),
+			new Date("2026-08-20T22:00:00Z"),
+		);
+		const keys = out.map((o) => o.key);
+		expect(new Set(keys).size).toBe(keys.length);
+	});
+});

--- a/src/tools/recurrence.test.ts
+++ b/src/tools/recurrence.test.ts
@@ -1,6 +1,11 @@
 import type { Event } from "ts-caldav";
 import { describe, expect, test } from "vitest";
-import { occurrencesWithin, toRRuleString } from "./recurrence.js";
+import {
+	occurrencesWithin,
+	replacedOccurrences,
+	toOccurrenceKey,
+	toRRuleString,
+} from "./recurrence.js";
 
 function makeEvent(overrides: Partial<Event> & Pick<Event, "start">): Event {
 	return {
@@ -190,5 +195,103 @@ describe("occurrencesWithin", () => {
 				),
 			),
 		).toEqual(["2026-08-18T12:00:00.000Z"]);
+	});
+});
+
+describe("toOccurrenceKey", () => {
+	test("accepts the shape ts-caldav hands over", () => {
+		expect(toOccurrenceKey("2026-08-21T14:30:00", false)).toBe(
+			"2026-08-21T14:30:00",
+		);
+	});
+
+	test("accepts the bare iCalendar form", () => {
+		expect(toOccurrenceKey("20260821T143000", false)).toBe(
+			"2026-08-21T14:30:00",
+		);
+		expect(toOccurrenceKey("20260821T143000Z", false)).toBe(
+			"2026-08-21T14:30:00",
+		);
+	});
+
+	test("reduces to the day for a whole-day series", () => {
+		expect(toOccurrenceKey("2026-08-21T00:00:00", true)).toBe("2026-08-21");
+		expect(toOccurrenceKey("20260821", true)).toBe("2026-08-21");
+	});
+
+	test("returns nothing for something unparseable", () => {
+		expect(toOccurrenceKey("next tuesday", false)).toBeUndefined();
+	});
+});
+
+describe("replacedOccurrences", () => {
+	test("groups the replaced slots by the uid of their series", () => {
+		const master = makeEvent({
+			start: new Date("2026-05-29T12:30:00Z"),
+			recurrenceRule: { freq: "WEEKLY", byday: ["FR"] },
+		});
+		const override = makeEvent({
+			uid: "test-uid",
+			start: new Date("2026-08-21T15:00:00Z"),
+			customFields: { "recurrence-id": "2026-08-21T14:30:00" },
+		});
+
+		const replaced = replacedOccurrences([master, override]);
+		expect(replaced.get("test-uid")).toEqual(new Set(["2026-08-21T14:30:00"]));
+	});
+
+	test("ignores events that replace nothing", () => {
+		const plain = makeEvent({ start: new Date("2026-08-21T12:30:00Z") });
+		expect(replacedOccurrences([plain]).size).toBe(0);
+	});
+});
+
+describe("occurrencesWithin robustness", () => {
+	test("skips the slot an override stands in for", () => {
+		// The master recurs every Friday at 14:30 Berlin time.
+		const master = makeEvent({
+			start: new Date("2026-08-14T12:30:00Z"),
+			recurrenceRule: { freq: "WEEKLY", byday: ["FR"] },
+		});
+		const window: [Date, Date] = [
+			new Date("2026-08-16T22:00:00Z"),
+			new Date("2026-08-23T22:00:00Z"),
+		];
+
+		expect(iso(occurrencesWithin(master, ...window))).toEqual([
+			"2026-08-21T12:30:00.000Z",
+		]);
+		expect(
+			occurrencesWithin(master, ...window, new Set(["2026-08-21T14:30:00"])),
+		).toEqual([]);
+	});
+
+	test("reaches a present-day window from a series that began decades ago", () => {
+		const ancient = makeEvent({
+			start: new Date("1990-01-01T09:00:00Z"),
+			recurrenceRule: { freq: "DAILY" },
+		});
+		const hits = occurrencesWithin(
+			ancient,
+			new Date("2026-08-17T00:00:00Z"),
+			new Date("2026-08-20T00:00:00Z"),
+		);
+		expect(hits).toHaveLength(3);
+	});
+
+	test("survives a time zone identifier that Intl rejects", () => {
+		// Exchange and older clients emit Windows zone names.
+		const exchange = makeEvent({
+			start: new Date("2026-08-21T12:30:00Z"),
+			startTzid: "W. Europe Standard Time",
+			recurrenceRule: { freq: "WEEKLY", byday: ["FR"] },
+		});
+		expect(() =>
+			occurrencesWithin(
+				exchange,
+				new Date("2026-08-16T22:00:00Z"),
+				new Date("2026-08-23T22:00:00Z"),
+			),
+		).not.toThrow();
 	});
 });

--- a/src/tools/recurrence.test.ts
+++ b/src/tools/recurrence.test.ts
@@ -1,0 +1,194 @@
+import type { Event } from "ts-caldav";
+import { describe, expect, test } from "vitest";
+import { occurrencesWithin, toRRuleString } from "./recurrence.js";
+
+function makeEvent(overrides: Partial<Event> & Pick<Event, "start">): Event {
+	return {
+		uid: "test-uid",
+		summary: "Test",
+		end: new Date(overrides.start.getTime() + 60 * 60 * 1000),
+		etag: "etag",
+		href: "/cal/test.ics",
+		startTzid: "Europe/Berlin",
+		...overrides,
+	} as Event;
+}
+
+const iso = (dates: Date[]) => dates.map((d) => d.toISOString());
+
+describe("toRRuleString", () => {
+	test("keeps only the parts that are set", () => {
+		expect(toRRuleString({ freq: "WEEKLY", byday: ["TU", "TH"] })).toBe(
+			"FREQ=WEEKLY;BYDAY=TU,TH",
+		);
+	});
+
+	test("translates the numeric WKST that ts-caldav hands over", () => {
+		// ts-caldav stringifies ical.js' weekday number, so Monday arrives as "2".
+		expect(toRRuleString({ freq: "WEEKLY", interval: 4, wkst: "2" })).toBe(
+			"FREQ=WEEKLY;INTERVAL=4;WKST=MO",
+		);
+		expect(toRRuleString({ freq: "WEEKLY", wkst: "1" })).toBe(
+			"FREQ=WEEKLY;WKST=SU",
+		);
+	});
+
+	test("drops a WKST it cannot make sense of", () => {
+		expect(toRRuleString({ freq: "WEEKLY", wkst: "nonsense" })).toBe(
+			"FREQ=WEEKLY",
+		);
+	});
+
+	test("renders UNTIL as a UTC timestamp", () => {
+		expect(
+			toRRuleString({
+				freq: "WEEKLY",
+				interval: 4,
+				wkst: "MO",
+				byday: ["FR"],
+				until: new Date("2027-05-30T12:30:00Z"),
+			}),
+		).toBe("FREQ=WEEKLY;INTERVAL=4;UNTIL=20270530T123000Z;WKST=MO;BYDAY=FR");
+	});
+});
+
+describe("occurrencesWithin", () => {
+	test("returns a single event only when it falls inside the window", () => {
+		const event = makeEvent({ start: new Date("2026-08-17T12:30:00Z") });
+		expect(
+			iso(
+				occurrencesWithin(
+					event,
+					new Date("2026-08-16T22:00:00Z"),
+					new Date("2026-08-23T22:00:00Z"),
+				),
+			),
+		).toEqual(["2026-08-17T12:30:00.000Z"]);
+		expect(
+			occurrencesWithin(
+				event,
+				new Date("2026-09-01T00:00:00Z"),
+				new Date("2026-09-08T00:00:00Z"),
+			),
+		).toEqual([]);
+	});
+
+	test("expands a weekly series that started years earlier", () => {
+		// The master DTSTART lies in 2024; a query for 2026 must not echo it back.
+		const event = makeEvent({
+			start: new Date("2024-09-10T12:00:00Z"),
+			recurrenceRule: { freq: "WEEKLY", byday: ["TU", "TH"] },
+		});
+		expect(
+			iso(
+				occurrencesWithin(
+					event,
+					new Date("2026-08-16T22:00:00Z"),
+					new Date("2026-08-23T22:00:00Z"),
+				),
+			),
+		).toEqual(["2026-08-18T12:00:00.000Z", "2026-08-20T12:00:00.000Z"]);
+	});
+
+	test("keeps the local clock time across a daylight saving change", () => {
+		// 14:00 in Berlin is 12:00Z in summer but 13:00Z in winter.
+		const event = makeEvent({
+			start: new Date("2024-09-10T12:00:00Z"),
+			recurrenceRule: { freq: "WEEKLY", byday: ["TU", "TH"] },
+		});
+		expect(
+			iso(
+				occurrencesWithin(
+					event,
+					new Date("2026-12-21T00:00:00Z"),
+					new Date("2026-12-25T00:00:00Z"),
+				),
+			),
+		).toEqual(["2026-12-22T13:00:00.000Z", "2026-12-24T13:00:00.000Z"]);
+	});
+
+	test("honours INTERVAL and UNTIL", () => {
+		const event = makeEvent({
+			start: new Date("2026-05-29T12:30:00Z"),
+			recurrenceRule: {
+				freq: "WEEKLY",
+				interval: 4,
+				wkst: "MO",
+				byday: ["FR"],
+				until: new Date("2027-05-30T12:30:00Z"),
+			},
+		});
+		expect(
+			iso(
+				occurrencesWithin(
+					event,
+					new Date("2026-08-16T22:00:00Z"),
+					new Date("2026-08-23T22:00:00Z"),
+				),
+			),
+		).toEqual(["2026-08-21T12:30:00.000Z"]);
+		expect(
+			occurrencesWithin(
+				event,
+				new Date("2027-08-01T00:00:00Z"),
+				new Date("2027-08-08T00:00:00Z"),
+			),
+		).toEqual([]);
+	});
+
+	test("drops occurrences listed in EXDATE", () => {
+		const event = makeEvent({
+			start: new Date("2024-09-10T12:00:00Z"),
+			recurrenceRule: { freq: "WEEKLY", byday: ["TU", "TH"] },
+			customFields: { exdate: "20260818T140000" },
+		});
+		expect(
+			iso(
+				occurrencesWithin(
+					event,
+					new Date("2026-08-16T22:00:00Z"),
+					new Date("2026-08-23T22:00:00Z"),
+				),
+			),
+		).toEqual(["2026-08-20T12:00:00.000Z"]);
+	});
+
+	test("keeps a yearly whole-day event on its own date", () => {
+		// A DTSTART;VALUE=DATE arrives from ical.js as *local* midnight and
+		// carries no TZID, so reading it as UTC would move the birthday a day.
+		const birthday = makeEvent({
+			start: new Date(1971, 6, 5),
+			wholeDay: true,
+			startTzid: undefined,
+			recurrenceRule: { freq: "YEARLY" },
+		});
+		expect(
+			occurrencesWithin(birthday, new Date(2026, 7, 17), new Date(2026, 7, 24)),
+		).toEqual([]);
+		expect(
+			iso(
+				occurrencesWithin(
+					birthday,
+					new Date(2026, 6, 1),
+					new Date(2026, 6, 31),
+				),
+			),
+		).toEqual([new Date(2026, 6, 5).toISOString()]);
+	});
+
+	test("falls back to the master when the rule carries no FREQ", () => {
+		const event = makeEvent({
+			start: new Date("2026-08-18T12:00:00Z"),
+			recurrenceRule: { byday: ["TU"] },
+		});
+		expect(
+			iso(
+				occurrencesWithin(
+					event,
+					new Date("2026-08-16T22:00:00Z"),
+					new Date("2026-08-23T22:00:00Z"),
+				),
+			),
+		).toEqual(["2026-08-18T12:00:00.000Z"]);
+	});
+});

--- a/src/tools/recurrence.test.ts
+++ b/src/tools/recurrence.test.ts
@@ -1,10 +1,9 @@
 import type { Event } from "ts-caldav";
 import { describe, expect, test } from "vitest";
 import {
+	expandEvents,
 	occurrencesWithin,
-	replacedOccurrences,
 	toOccurrenceKey,
-	toRRuleString,
 } from "./recurrence.js";
 
 function makeEvent(overrides: Partial<Event> & Pick<Event, "start">): Event {
@@ -20,42 +19,6 @@ function makeEvent(overrides: Partial<Event> & Pick<Event, "start">): Event {
 }
 
 const iso = (dates: Date[]) => dates.map((d) => d.toISOString());
-
-describe("toRRuleString", () => {
-	test("keeps only the parts that are set", () => {
-		expect(toRRuleString({ freq: "WEEKLY", byday: ["TU", "TH"] })).toBe(
-			"FREQ=WEEKLY;BYDAY=TU,TH",
-		);
-	});
-
-	test("translates the numeric WKST that ts-caldav hands over", () => {
-		// ts-caldav stringifies ical.js' weekday number, so Monday arrives as "2".
-		expect(toRRuleString({ freq: "WEEKLY", interval: 4, wkst: "2" })).toBe(
-			"FREQ=WEEKLY;INTERVAL=4;WKST=MO",
-		);
-		expect(toRRuleString({ freq: "WEEKLY", wkst: "1" })).toBe(
-			"FREQ=WEEKLY;WKST=SU",
-		);
-	});
-
-	test("drops a WKST it cannot make sense of", () => {
-		expect(toRRuleString({ freq: "WEEKLY", wkst: "nonsense" })).toBe(
-			"FREQ=WEEKLY",
-		);
-	});
-
-	test("renders UNTIL as a UTC timestamp", () => {
-		expect(
-			toRRuleString({
-				freq: "WEEKLY",
-				interval: 4,
-				wkst: "MO",
-				byday: ["FR"],
-				until: new Date("2027-05-30T12:30:00Z"),
-			}),
-		).toBe("FREQ=WEEKLY;INTERVAL=4;UNTIL=20270530T123000Z;WKST=MO;BYDAY=FR");
-	});
-});
 
 describe("occurrencesWithin", () => {
 	test("returns a single event only when it falls inside the window", () => {
@@ -224,28 +187,6 @@ describe("toOccurrenceKey", () => {
 	});
 });
 
-describe("replacedOccurrences", () => {
-	test("groups the replaced slots by the uid of their series", () => {
-		const master = makeEvent({
-			start: new Date("2026-05-29T12:30:00Z"),
-			recurrenceRule: { freq: "WEEKLY", byday: ["FR"] },
-		});
-		const override = makeEvent({
-			uid: "test-uid",
-			start: new Date("2026-08-21T15:00:00Z"),
-			customFields: { "recurrence-id": "2026-08-21T14:30:00" },
-		});
-
-		const replaced = replacedOccurrences([master, override]);
-		expect(replaced.get("test-uid")).toEqual(new Set(["2026-08-21T14:30:00"]));
-	});
-
-	test("ignores events that replace nothing", () => {
-		const plain = makeEvent({ start: new Date("2026-08-21T12:30:00Z") });
-		expect(replacedOccurrences([plain]).size).toBe(0);
-	});
-});
-
 describe("occurrencesWithin robustness", () => {
 	test("skips the slot an override stands in for", () => {
 		// The master recurs every Friday at 14:30 Berlin time.
@@ -293,5 +234,128 @@ describe("occurrencesWithin robustness", () => {
 				new Date("2026-08-23T22:00:00Z"),
 			),
 		).not.toThrow();
+	});
+});
+
+describe("seeding near the window", () => {
+	// The seed jump skips whole periods. If it landed on the wrong phase, an
+	// interval series would come back on the wrong days rather than not at all,
+	// so these pin the dates and not just the count.
+	test("keeps the phase of a four-weekly series across decades", () => {
+		const event = makeEvent({
+			start: new Date("1990-01-05T12:30:00Z"), // a Friday
+			recurrenceRule: { freq: "WEEKLY", interval: 4, byday: ["FR"] },
+		});
+		// Checked against a full walk from 1990 with no seed jump: the phase lands
+		// on 28 August, not on the 21st. The start is 13:30 Berlin time in winter,
+		// so 36 years later it is still 13:30 there, which is 11:30 UTC in summer.
+		expect(
+			iso(
+				occurrencesWithin(
+					event,
+					new Date("2026-08-23T22:00:00Z"),
+					new Date("2026-08-30T22:00:00Z"),
+				),
+			),
+		).toEqual(["2026-08-28T11:30:00.000Z"]);
+		// The neighbouring week belongs to another phase and must stay empty.
+		expect(
+			occurrencesWithin(
+				event,
+				new Date("2026-08-16T22:00:00Z"),
+				new Date("2026-08-23T22:00:00Z"),
+			),
+		).toEqual([]);
+	});
+
+	test("does not skip ahead of a series bounded by COUNT", () => {
+		const event = makeEvent({
+			start: new Date("2026-08-03T12:30:00Z"),
+			recurrenceRule: { freq: "DAILY", count: 3 },
+		});
+		expect(
+			occurrencesWithin(
+				event,
+				new Date("2026-08-16T22:00:00Z"),
+				new Date("2026-08-23T22:00:00Z"),
+			),
+		).toEqual([]);
+		expect(
+			iso(
+				occurrencesWithin(
+					event,
+					new Date("2026-08-02T22:00:00Z"),
+					new Date("2026-08-09T22:00:00Z"),
+				),
+			),
+		).toHaveLength(3);
+	});
+
+	test("accepts the numeric WKST that ts-caldav hands over", () => {
+		const event = makeEvent({
+			start: new Date("2026-05-29T12:30:00Z"),
+			recurrenceRule: {
+				freq: "WEEKLY",
+				interval: 4,
+				wkst: "2",
+				byday: ["FR"],
+				until: new Date("2027-05-30T12:30:00Z"),
+			},
+		});
+		expect(
+			iso(
+				occurrencesWithin(
+					event,
+					new Date("2026-08-16T22:00:00Z"),
+					new Date("2026-08-23T22:00:00Z"),
+				),
+			),
+		).toEqual(["2026-08-21T12:30:00.000Z"]);
+	});
+});
+
+describe("expandEvents", () => {
+	const master = makeEvent({
+		start: new Date("2026-08-14T12:30:00Z"),
+		recurrenceRule: { freq: "WEEKLY", byday: ["FR"] },
+	});
+	const override = makeEvent({
+		uid: "test-uid",
+		start: new Date("2026-08-21T15:00:00Z"),
+		customFields: { "recurrence-id": "2026-08-21T14:30:00" },
+	});
+	const window: [Date, Date] = [
+		new Date("2026-08-16T22:00:00Z"),
+		new Date("2026-08-23T22:00:00Z"),
+	];
+
+	test("reports a moved occurrence once, at its new time", () => {
+		const out = expandEvents([master, override], ...window);
+		expect(iso(out.map((o) => o.start))).toEqual(["2026-08-21T15:00:00.000Z"]);
+	});
+
+	test("identifies a replacement by the slot it stands in for", () => {
+		const [only] = expandEvents([master, override], ...window);
+		expect(only?.key).toBe("2026-08-21T14:30:00");
+		expect(only?.fromSeries).toBe(true);
+	});
+
+	test("gives a plain event its own slot as key", () => {
+		const plain = makeEvent({ start: new Date("2026-08-18T09:00:00Z") });
+		const [only] = expandEvents([plain], ...window);
+		expect(only?.key).toBe("2026-08-18T11:00:00");
+		expect(only?.fromSeries).toBe(false);
+	});
+
+	test("returns occurrences oldest first across events", () => {
+		const other = makeEvent({
+			uid: "other",
+			start: new Date("2026-08-17T08:00:00Z"),
+		});
+		const out = expandEvents([master, override, other], ...window);
+		expect(iso(out.map((o) => o.start))).toEqual([
+			"2026-08-17T08:00:00.000Z",
+			"2026-08-21T15:00:00.000Z",
+		]);
 	});
 });

--- a/src/tools/recurrence.ts
+++ b/src/tools/recurrence.ts
@@ -178,7 +178,14 @@ function exceptionKeys(event: Event, isDate: boolean): Set<string> {
 	return keys;
 }
 
+/**
+ * The slot a replacement event stands in for, if it is one. An event carrying a
+ * rule of its own is not treated as a replacement: RFC 5545 does not allow the
+ * combination, and honouring it would stamp every occurrence it expands into
+ * with the same key.
+ */
 function recurrenceIdKey(event: Event): string | undefined {
+	if (event.recurrenceRule?.freq) return undefined;
 	const raw = event.customFields?.["recurrence-id"];
 	return typeof raw === "string"
 		? toOccurrenceKey(raw, event.wholeDay === true)
@@ -211,6 +218,11 @@ function toRecur(rule: RecurrenceRule): ICAL.Recur | undefined {
  * steps. COUNT is left alone, because there the position from the start decides
  * when the series ends. The jump lands one period short so the iterator, not
  * this arithmetic, picks the first occurrence.
+ *
+ * Note this hands `iterator()` something other than the real DTSTART, which the
+ * ical.js docs do not promise to support. It holds because the jump is an exact
+ * multiple of the period and the algorithm only looks at the phase, but an
+ * ical.js upgrade is a reason to re-check it.
  */
 function seedNear(
 	start: ICAL.Time,

--- a/src/tools/recurrence.ts
+++ b/src/tools/recurrence.ts
@@ -1,0 +1,263 @@
+import ICAL from "ical.js";
+import type { Event, RecurrenceRule } from "ts-caldav";
+
+/**
+ * Client side expansion of recurring events.
+ *
+ * `getEvents` can ask the server to expand a series (RFC 4791 `<C:expand>`),
+ * but a server is free to ignore that, and several do — Open-Xchange, and so
+ * mailbox.org, returns the series master with its RRULE untouched. Callers
+ * then see the original DTSTART of the series instead of the occurrences that
+ * fall inside the requested window, which is worse than useless: a query for
+ * next week answers with a date from two years ago.
+ *
+ * Expanding here keeps the tool honest whatever the server does.
+ */
+
+/** Guards against an unbounded rule combined with a far away window. */
+const MAX_OCCURRENCES = 10_000;
+
+function pad(value: number, length = 2): string {
+	return String(value).padStart(length, "0");
+}
+
+/** ical.js numbers the weekdays from Sunday; ts-caldav passes that number on. */
+const WEEKDAY_BY_NUMBER = ["SU", "MO", "TU", "WE", "TH", "FR", "SA"];
+
+/**
+ * ts-caldav stringifies `wkst` straight off ical.js, so it arrives as "2"
+ * rather than "MO". Feeding that back into an RRULE makes ical.js reject the
+ * rule, which would drop the series entirely.
+ */
+function toWeekday(wkst: string): string | undefined {
+	const trimmed = wkst.trim().toUpperCase();
+	if (WEEKDAY_BY_NUMBER.includes(trimmed)) return trimmed;
+	const numeric = Number(trimmed);
+	return Number.isInteger(numeric) ? WEEKDAY_BY_NUMBER[numeric - 1] : undefined;
+}
+
+/** Rebuilds an RFC 5545 RRULE from the structure ts-caldav parses for us. */
+export function toRRuleString(rule: RecurrenceRule): string {
+	const parts: string[] = [];
+	if (rule.freq) parts.push(`FREQ=${rule.freq}`);
+	if (rule.interval && rule.interval > 1)
+		parts.push(`INTERVAL=${rule.interval}`);
+	if (rule.count) parts.push(`COUNT=${rule.count}`);
+	if (rule.until) {
+		const u = rule.until;
+		parts.push(
+			`UNTIL=${u.getUTCFullYear()}${pad(u.getUTCMonth() + 1)}${pad(u.getUTCDate())}T${pad(u.getUTCHours())}${pad(u.getUTCMinutes())}${pad(u.getUTCSeconds())}Z`,
+		);
+	}
+	const wkst = rule.wkst ? toWeekday(rule.wkst) : undefined;
+	if (wkst) parts.push(`WKST=${wkst}`);
+	if (rule.byday?.length) parts.push(`BYDAY=${rule.byday.join(",")}`);
+	if (rule.bymonthday?.length)
+		parts.push(`BYMONTHDAY=${rule.bymonthday.join(",")}`);
+	if (rule.bymonth?.length) parts.push(`BYMONTH=${rule.bymonth.join(",")}`);
+	return parts.join(";");
+}
+
+type WallClock = {
+	year: number;
+	month: number;
+	day: number;
+	hour: number;
+	minute: number;
+	second: number;
+};
+
+function wallClockIn(instant: Date, timeZone: string): WallClock {
+	const parts = new Intl.DateTimeFormat("en-US", {
+		timeZone,
+		hour12: false,
+		year: "numeric",
+		month: "2-digit",
+		day: "2-digit",
+		hour: "2-digit",
+		minute: "2-digit",
+		second: "2-digit",
+	}).formatToParts(instant);
+	const get = (type: string) =>
+		Number(parts.find((part) => part.type === type)?.value ?? "0");
+	// Intl renders midnight as hour 24 in some engines.
+	const hour = get("hour") % 24;
+	return {
+		year: get("year"),
+		month: get("month"),
+		day: get("day"),
+		hour,
+		minute: get("minute"),
+		second: get("second"),
+	};
+}
+
+/** Milliseconds between a zone's wall clock and UTC at a given instant. */
+function zoneOffset(instant: Date, timeZone: string): number {
+	const w = wallClockIn(instant, timeZone);
+	const asUTC = Date.UTC(
+		w.year,
+		w.month - 1,
+		w.day,
+		w.hour,
+		w.minute,
+		w.second,
+	);
+	// The wall clock carries no milliseconds, so compare on whole seconds.
+	return asUTC - (instant.getTime() - instant.getMilliseconds());
+}
+
+/**
+ * Turns a wall clock reading into the instant it denotes in `timeZone`.
+ * Two passes, because the offset itself depends on the instant we are looking
+ * for; the second pass settles everything except the hour that a DST jump
+ * skips, where any answer is a convention anyway.
+ */
+function instantFromWallClock(wall: WallClock, timeZone: string): Date {
+	const asUTC = Date.UTC(
+		wall.year,
+		wall.month - 1,
+		wall.day,
+		wall.hour,
+		wall.minute,
+		wall.second,
+	);
+	let guess = asUTC - zoneOffset(new Date(asUTC), timeZone);
+	guess = asUTC - zoneOffset(new Date(guess), timeZone);
+	return new Date(guess);
+}
+
+function toICALTime(wall: WallClock, isDate: boolean): ICAL.Time {
+	// Floating time on purpose: the zone is applied afterwards by
+	// instantFromWallClock, which is what keeps the local hour stable across a
+	// daylight saving change.
+	return new ICAL.Time(
+		{
+			year: wall.year,
+			month: wall.month,
+			day: wall.day,
+			hour: isDate ? 0 : wall.hour,
+			minute: isDate ? 0 : wall.minute,
+			second: isDate ? 0 : wall.second,
+			isDate,
+		},
+		ICAL.Timezone.localTimezone,
+	);
+}
+
+function fromICALTime(time: ICAL.Time): WallClock {
+	return {
+		year: time.year,
+		month: time.month,
+		day: time.day,
+		hour: time.hour,
+		minute: time.minute,
+		second: time.second,
+	};
+}
+
+/**
+ * The zone an event's `start` has to be read in.
+ *
+ * A DTSTART without a TZID — a whole-day date, or a floating time — is turned
+ * into a `Date` at *local* midnight by ical.js, not at UTC midnight. Reading it
+ * back as UTC shifts a whole-day event by a day in any zone east of Greenwich,
+ * which is how a birthday ends up reported one day early.
+ */
+function zoneOf(event: Event): string {
+	return (
+		event.startTzid || Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC"
+	);
+}
+
+function asArray(value: string | string[] | undefined): string[] {
+	if (value === undefined) return [];
+	return Array.isArray(value) ? value : [value];
+}
+
+/**
+ * Instants the series skips. ts-caldav keeps EXDATE in `customFields` and only
+ * retains the first value of each property, so a property listing several
+ * dates at once contributes just one. Excluding what we can beats excluding
+ * nothing; the alternative is showing meetings that were cancelled.
+ */
+function exceptionInstants(event: Event, timeZone: string): Set<number> {
+	const raw = asArray(event.customFields?.exdate).concat(
+		asArray(event.customFields?.EXDATE),
+	);
+	const instants = new Set<number>();
+	for (const entry of raw) {
+		for (const piece of entry.split(",")) {
+			const parsed = new Date(piece.trim());
+			if (!Number.isNaN(parsed.getTime())) {
+				instants.add(parsed.getTime());
+				continue;
+			}
+			// Bare iCalendar form, e.g. 20251202T140000 without a zone marker.
+			const match = piece
+				.trim()
+				.match(/^(\d{4})(\d{2})(\d{2})(?:T(\d{2})(\d{2})(\d{2}))?Z?$/);
+			if (!match) continue;
+			const [, y, mo, d, h = "0", mi = "0", s = "0"] = match;
+			instants.add(
+				instantFromWallClock(
+					{
+						year: Number(y),
+						month: Number(mo),
+						day: Number(d),
+						hour: Number(h),
+						minute: Number(mi),
+						second: Number(s),
+					},
+					timeZone,
+				).getTime(),
+			);
+		}
+	}
+	return instants;
+}
+
+/**
+ * Start instants of every occurrence of `event` inside `[windowStart, windowEnd)`.
+ * A single event yields at most one entry. Expansion runs on the wall clock of
+ * the event's own zone, so a weekly 14:00 appointment stays at 14:00 across a
+ * daylight saving change instead of drifting by an hour.
+ */
+export function occurrencesWithin(
+	event: Event,
+	windowStart: Date,
+	windowEnd: Date,
+): Date[] {
+	const startsInWindow = (instant: Date) =>
+		instant >= windowStart && instant < windowEnd;
+
+	if (!event.recurrenceRule) {
+		return startsInWindow(event.start) ? [event.start] : [];
+	}
+
+	const rruleString = toRRuleString(event.recurrenceRule);
+	if (!rruleString.startsWith("FREQ=")) {
+		// Nothing usable to expand; report the master rather than dropping it.
+		return startsInWindow(event.start) ? [event.start] : [];
+	}
+
+	const timeZone = zoneOf(event);
+	const isDate = event.wholeDay === true;
+	const excluded = exceptionInstants(event, timeZone);
+
+	const iterator = ICAL.Recur.fromString(rruleString).iterator(
+		toICALTime(wallClockIn(event.start, timeZone), isDate),
+	);
+
+	const found: Date[] = [];
+	for (let seen = 0; seen < MAX_OCCURRENCES; seen += 1) {
+		const next = iterator.next();
+		if (!next) break;
+		const instant = instantFromWallClock(fromICALTime(next), timeZone);
+		if (instant >= windowEnd) break;
+		if (startsInWindow(instant) && !excluded.has(instant.getTime())) {
+			found.push(instant);
+		}
+	}
+	return found;
+}

--- a/src/tools/recurrence.ts
+++ b/src/tools/recurrence.ts
@@ -14,8 +14,16 @@ import type { Event, RecurrenceRule } from "ts-caldav";
  * Expanding here keeps the tool honest whatever the server does.
  */
 
-/** Guards against an unbounded rule combined with a far away window. */
-const MAX_OCCURRENCES = 10_000;
+/**
+ * Stops a rule that never terminates. High enough that a daily series running
+ * since the 1980s still reaches a present-day window, because the walk to get
+ * there costs almost nothing: only occurrences near the window are converted
+ * into instants.
+ */
+const MAX_STEPS = 100_000;
+
+/** How far outside the window an occurrence may look before it is discarded. */
+const WALL_CLOCK_MARGIN_DAYS = 1;
 
 function pad(value: number, length = 2): string {
 	return String(value).padStart(length, "0");
@@ -67,8 +75,13 @@ type WallClock = {
 	second: number;
 };
 
-function wallClockIn(instant: Date, timeZone: string): WallClock {
-	const parts = new Intl.DateTimeFormat("en-US", {
+/** One formatter per zone; expansion asks for the same zone thousands of times. */
+const formatters = new Map<string, Intl.DateTimeFormat>();
+
+function formatterFor(timeZone: string): Intl.DateTimeFormat {
+	const cached = formatters.get(timeZone);
+	if (cached) return cached;
+	const created = new Intl.DateTimeFormat("en-US", {
 		timeZone,
 		hour12: false,
 		year: "numeric",
@@ -77,7 +90,13 @@ function wallClockIn(instant: Date, timeZone: string): WallClock {
 		hour: "2-digit",
 		minute: "2-digit",
 		second: "2-digit",
-	}).formatToParts(instant);
+	});
+	formatters.set(timeZone, created);
+	return created;
+}
+
+function wallClockIn(instant: Date, timeZone: string): WallClock {
+	const parts = formatterFor(timeZone).formatToParts(instant);
 	const get = (type: string) =>
 		Number(parts.find((part) => part.type === type)?.value ?? "0");
 	// Intl renders midnight as hour 24 in some engines.
@@ -110,8 +129,8 @@ function zoneOffset(instant: Date, timeZone: string): number {
 /**
  * Turns a wall clock reading into the instant it denotes in `timeZone`.
  * Two passes, because the offset itself depends on the instant we are looking
- * for; the second pass settles everything except the hour that a DST jump
- * skips, where any answer is a convention anyway.
+ * for; the second pass settles everything except the hour a daylight saving
+ * jump skips or repeats, where any answer is a convention anyway.
  */
 function instantFromWallClock(wall: WallClock, timeZone: string): Date {
 	const asUTC = Date.UTC(
@@ -163,11 +182,55 @@ function fromICALTime(time: ICAL.Time): WallClock {
  * into a `Date` at *local* midnight by ical.js, not at UTC midnight. Reading it
  * back as UTC shifts a whole-day event by a day in any zone east of Greenwich,
  * which is how a birthday ends up reported one day early.
+ *
+ * A TZID is whatever the writing client put there. Exchange and some older
+ * tools emit Windows zone names ("W. Europe Standard Time") that `Intl` refuses,
+ * so an unusable zone falls back to the local one rather than throwing and
+ * taking the whole query down with it.
  */
 function zoneOf(event: Event): string {
-	return (
-		event.startTzid || Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC"
+	const local = Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
+	const declared = event.startTzid;
+	if (!declared) return local;
+	try {
+		formatterFor(declared);
+		return declared;
+	} catch {
+		return local;
+	}
+}
+
+/**
+ * Identifies an occurrence by its wall clock rather than by an instant.
+ *
+ * RECURRENCE-ID and EXDATE both name an occurrence in the series' own local
+ * terms, and ts-caldav hands them over as a bare `2026-08-21T14:30:00` with the
+ * TZID parameter already dropped. Comparing wall clocks sidesteps the missing
+ * zone entirely.
+ */
+function occurrenceKey(wall: WallClock, isDate: boolean): string {
+	const day = `${wall.year}-${pad(wall.month)}-${pad(wall.day)}`;
+	return isDate
+		? day
+		: `${day}T${pad(wall.hour)}:${pad(wall.minute)}:${pad(wall.second)}`;
+}
+
+/** Normalises a stored RECURRENCE-ID or EXDATE into the same shape. */
+export function toOccurrenceKey(
+	value: string,
+	isDate: boolean,
+): string | undefined {
+	const trimmed = value.trim().replace(/Z$/, "");
+	const iso = trimmed.match(
+		/^(\d{4})-(\d{2})-(\d{2})(?:T(\d{2}):(\d{2}):(\d{2}))?/,
 	);
+	const basic = trimmed.match(
+		/^(\d{4})(\d{2})(\d{2})(?:T(\d{2})(\d{2})(\d{2}))?$/,
+	);
+	const m = iso ?? basic;
+	if (!m) return undefined;
+	const [, y, mo, d, h = "00", mi = "00", s = "00"] = m;
+	return isDate ? `${y}-${mo}-${d}` : `${y}-${mo}-${d}T${h}:${mi}:${s}`;
 }
 
 function asArray(value: string | string[] | undefined): string[] {
@@ -176,45 +239,28 @@ function asArray(value: string | string[] | undefined): string[] {
 }
 
 /**
- * Instants the series skips. ts-caldav keeps EXDATE in `customFields` and only
- * retains the first value of each property, so a property listing several
- * dates at once contributes just one. Excluding what we can beats excluding
- * nothing; the alternative is showing meetings that were cancelled.
+ * Occurrences the series itself declares as skipped.
+ *
+ * ts-caldav keeps EXDATE in `customFields` and retains only the first value of
+ * each property, so a property listing several dates at once contributes just
+ * one of them. Excluding what does arrive still beats excluding nothing; the
+ * alternative is showing meetings that were cancelled.
  */
-function exceptionInstants(event: Event, timeZone: string): Set<number> {
-	const raw = asArray(event.customFields?.exdate).concat(
-		asArray(event.customFields?.EXDATE),
-	);
-	const instants = new Set<number>();
-	for (const entry of raw) {
+function exceptionKeys(event: Event, isDate: boolean): Set<string> {
+	const keys = new Set<string>();
+	for (const entry of asArray(event.customFields?.exdate)) {
 		for (const piece of entry.split(",")) {
-			const parsed = new Date(piece.trim());
-			if (!Number.isNaN(parsed.getTime())) {
-				instants.add(parsed.getTime());
-				continue;
-			}
-			// Bare iCalendar form, e.g. 20251202T140000 without a zone marker.
-			const match = piece
-				.trim()
-				.match(/^(\d{4})(\d{2})(\d{2})(?:T(\d{2})(\d{2})(\d{2}))?Z?$/);
-			if (!match) continue;
-			const [, y, mo, d, h = "0", mi = "0", s = "0"] = match;
-			instants.add(
-				instantFromWallClock(
-					{
-						year: Number(y),
-						month: Number(mo),
-						day: Number(d),
-						hour: Number(h),
-						minute: Number(mi),
-						second: Number(s),
-					},
-					timeZone,
-				).getTime(),
-			);
+			const key = toOccurrenceKey(piece, isDate);
+			if (key) keys.add(key);
 		}
 	}
-	return instants;
+	return keys;
+}
+
+/** The RECURRENCE-ID of an event, if it is a replacement for one occurrence. */
+function recurrenceIdOf(event: Event): string | undefined {
+	const raw = event.customFields?.["recurrence-id"];
+	return typeof raw === "string" ? raw : undefined;
 }
 
 /**
@@ -222,11 +268,16 @@ function exceptionInstants(event: Event, timeZone: string): Set<number> {
  * A single event yields at most one entry. Expansion runs on the wall clock of
  * the event's own zone, so a weekly 14:00 appointment stays at 14:00 across a
  * daylight saving change instead of drifting by an hour.
+ *
+ * `replaced` holds the keys of occurrences that a separate override event
+ * stands in for; those are skipped so a rescheduled meeting is not reported
+ * twice, once at its old slot and once at its new one.
  */
 export function occurrencesWithin(
 	event: Event,
 	windowStart: Date,
 	windowEnd: Date,
+	replaced: ReadonlySet<string> = new Set(),
 ): Date[] {
 	const startsInWindow = (instant: Date) =>
 		instant >= windowStart && instant < windowEnd;
@@ -243,21 +294,57 @@ export function occurrencesWithin(
 
 	const timeZone = zoneOf(event);
 	const isDate = event.wholeDay === true;
-	const excluded = exceptionInstants(event, timeZone);
+	const skip = exceptionKeys(event, isDate);
+
+	// Compare in wall clock while walking, so reaching a window decades after
+	// the series began costs no zone conversions at all.
+	const margin = WALL_CLOCK_MARGIN_DAYS * 24 * 60 * 60 * 1000;
+	const lower = toICALTime(
+		wallClockIn(new Date(windowStart.getTime() - margin), timeZone),
+		false,
+	);
+	const upper = toICALTime(
+		wallClockIn(new Date(windowEnd.getTime() + margin), timeZone),
+		false,
+	);
 
 	const iterator = ICAL.Recur.fromString(rruleString).iterator(
 		toICALTime(wallClockIn(event.start, timeZone), isDate),
 	);
 
 	const found: Date[] = [];
-	for (let seen = 0; seen < MAX_OCCURRENCES; seen += 1) {
+	for (let step = 0; step < MAX_STEPS; step += 1) {
 		const next = iterator.next();
 		if (!next) break;
-		const instant = instantFromWallClock(fromICALTime(next), timeZone);
-		if (instant >= windowEnd) break;
-		if (startsInWindow(instant) && !excluded.has(instant.getTime())) {
-			found.push(instant);
-		}
+		if (next.compare(upper) > 0) break;
+		if (next.compare(lower) < 0) continue;
+
+		const wall = fromICALTime(next);
+		const key = occurrenceKey(wall, isDate);
+		if (skip.has(key) || replaced.has(key)) continue;
+
+		const instant = instantFromWallClock(wall, timeZone);
+		if (startsInWindow(instant)) found.push(instant);
 	}
 	return found;
+}
+
+/**
+ * Keys of the occurrences that `events` replace, grouped by the uid of the
+ * series they belong to.
+ */
+export function replacedOccurrences(
+	events: readonly Event[],
+): Map<string, Set<string>> {
+	const byUid = new Map<string, Set<string>>();
+	for (const event of events) {
+		const raw = recurrenceIdOf(event);
+		if (!raw) continue;
+		const key = toOccurrenceKey(raw, event.wholeDay === true);
+		if (!key) continue;
+		const keys = byUid.get(event.uid) ?? new Set<string>();
+		keys.add(key);
+		byUid.set(event.uid, keys);
+	}
+	return byUid;
 }

--- a/src/tools/recurrence.ts
+++ b/src/tools/recurrence.ts
@@ -4,76 +4,37 @@ import type { Event, RecurrenceRule } from "ts-caldav";
 /**
  * Client side expansion of recurring events.
  *
- * `getEvents` can ask the server to expand a series (RFC 4791 `<C:expand>`),
- * but a server is free to ignore that, and several do — Open-Xchange, and so
- * mailbox.org, returns the series master with its RRULE untouched. Callers
- * then see the original DTSTART of the series instead of the occurrences that
- * fall inside the requested window, which is worse than useless: a query for
- * next week answers with a date from two years ago.
+ * `getEvents` asks the server to expand a series (RFC 4791 `<C:expand>`), but a
+ * server may ignore it: Open-Xchange, and so mailbox.org, returns the master
+ * with its RRULE untouched, so a query for next week answers with the DTSTART
+ * of a series that began years ago. Where the server did the work, events
+ * arrive without a rule and pass straight through.
  *
- * Expanding here keeps the tool honest whatever the server does.
+ * Two limits come from what ts-caldav models. A rule keeps only FREQ, INTERVAL,
+ * COUNT, UNTIL, WKST, BYDAY, BYMONTHDAY and BYMONTH, so one built on BYSETPOS
+ * ("last weekday of the month") expands too generously. And only the first
+ * value of a repeated EXDATE survives, so a line cancelling several dates at
+ * once excludes one of them.
  */
 
-/**
- * Stops a rule that never terminates. High enough that a daily series running
- * since the 1980s still reaches a present-day window, because the walk to get
- * there costs almost nothing: only occurrences near the window are converted
- * into instants.
- */
+/** Stops a rule that never terminates. */
 const MAX_STEPS = 100_000;
 
-/** How far outside the window an occurrence may look before it is discarded. */
-const WALL_CLOCK_MARGIN_DAYS = 1;
+const DAY_MS = 24 * 60 * 60 * 1000;
 
-function pad(value: number, length = 2): string {
-	return String(value).padStart(length, "0");
-}
+/** How far outside the window a candidate may look before it is discarded. */
+const MARGIN_MS = DAY_MS;
 
-/** ical.js numbers the weekdays from Sunday; ts-caldav passes that number on. */
-const WEEKDAY_BY_NUMBER = ["SU", "MO", "TU", "WE", "TH", "FR", "SA"];
+const NO_KEYS: ReadonlySet<string> = new Set();
 
-/**
- * ts-caldav stringifies `wkst` straight off ical.js, so it arrives as "2"
- * rather than "MO". Feeding that back into an RRULE makes ical.js reject the
- * rule, which would drop the series entirely.
- */
-function toWeekday(wkst: string): string | undefined {
-	const trimmed = wkst.trim().toUpperCase();
-	if (WEEKDAY_BY_NUMBER.includes(trimmed)) return trimmed;
-	const numeric = Number(trimmed);
-	return Number.isInteger(numeric) ? WEEKDAY_BY_NUMBER[numeric - 1] : undefined;
-}
+let systemZoneCache: string | undefined;
 
-/** Rebuilds an RFC 5545 RRULE from the structure ts-caldav parses for us. */
-export function toRRuleString(rule: RecurrenceRule): string {
-	const parts: string[] = [];
-	if (rule.freq) parts.push(`FREQ=${rule.freq}`);
-	if (rule.interval && rule.interval > 1)
-		parts.push(`INTERVAL=${rule.interval}`);
-	if (rule.count) parts.push(`COUNT=${rule.count}`);
-	if (rule.until) {
-		const u = rule.until;
-		parts.push(
-			`UNTIL=${u.getUTCFullYear()}${pad(u.getUTCMonth() + 1)}${pad(u.getUTCDate())}T${pad(u.getUTCHours())}${pad(u.getUTCMinutes())}${pad(u.getUTCSeconds())}Z`,
-		);
+function systemZone(): string {
+	if (!systemZoneCache) {
+		systemZoneCache = Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
 	}
-	const wkst = rule.wkst ? toWeekday(rule.wkst) : undefined;
-	if (wkst) parts.push(`WKST=${wkst}`);
-	if (rule.byday?.length) parts.push(`BYDAY=${rule.byday.join(",")}`);
-	if (rule.bymonthday?.length)
-		parts.push(`BYMONTHDAY=${rule.bymonthday.join(",")}`);
-	if (rule.bymonth?.length) parts.push(`BYMONTH=${rule.bymonth.join(",")}`);
-	return parts.join(";");
+	return systemZoneCache;
 }
-
-type WallClock = {
-	year: number;
-	month: number;
-	day: number;
-	hour: number;
-	minute: number;
-	second: number;
-};
 
 /** One formatter per zone; expansion asks for the same zone thousands of times. */
 const formatters = new Map<string, Intl.DateTimeFormat>();
@@ -95,25 +56,49 @@ function formatterFor(timeZone: string): Intl.DateTimeFormat {
 	return created;
 }
 
-function wallClockIn(instant: Date, timeZone: string): WallClock {
-	const parts = formatterFor(timeZone).formatToParts(instant);
-	const get = (type: string) =>
-		Number(parts.find((part) => part.type === type)?.value ?? "0");
-	// Intl renders midnight as hour 24 in some engines.
-	const hour = get("hour") % 24;
-	return {
-		year: get("year"),
-		month: get("month"),
-		day: get("day"),
-		hour,
-		minute: get("minute"),
-		second: get("second"),
-	};
+/**
+ * The instant as it reads on a clock in `timeZone`, as a floating ICAL.Time.
+ * Floating on purpose: `instantOf` applies the zone again, and that pair is what
+ * keeps a weekly 14:00 appointment at 14:00 across a daylight saving change.
+ */
+function floatingTimeIn(
+	instant: Date,
+	timeZone: string,
+	isDate = false,
+): ICAL.Time {
+	let year = 0;
+	let month = 1;
+	let day = 1;
+	let hour = 0;
+	let minute = 0;
+	let second = 0;
+	for (const part of formatterFor(timeZone).formatToParts(instant)) {
+		const value = Number(part.value);
+		if (part.type === "year") year = value;
+		else if (part.type === "month") month = value;
+		else if (part.type === "day") day = value;
+		// Some engines render midnight as hour 24.
+		else if (part.type === "hour") hour = value % 24;
+		else if (part.type === "minute") minute = value;
+		else if (part.type === "second") second = value;
+	}
+	return new ICAL.Time(
+		{
+			year,
+			month,
+			day,
+			hour: isDate ? 0 : hour,
+			minute: isDate ? 0 : minute,
+			second: isDate ? 0 : second,
+			isDate,
+		},
+		ICAL.Timezone.localTimezone,
+	);
 }
 
 /** Milliseconds between a zone's wall clock and UTC at a given instant. */
 function zoneOffset(instant: Date, timeZone: string): number {
-	const w = wallClockIn(instant, timeZone);
+	const w = floatingTimeIn(instant, timeZone);
 	const asUTC = Date.UTC(
 		w.year,
 		w.month - 1,
@@ -127,107 +112,53 @@ function zoneOffset(instant: Date, timeZone: string): number {
 }
 
 /**
- * Turns a wall clock reading into the instant it denotes in `timeZone`.
- * Two passes, because the offset itself depends on the instant we are looking
- * for; the second pass settles everything except the hour a daylight saving
- * jump skips or repeats, where any answer is a convention anyway.
+ * The instant a floating time denotes in `timeZone`. Two passes, because the
+ * offset depends on the instant being looked for; only the hour a daylight
+ * saving jump skips or repeats stays a matter of convention.
  */
-function instantFromWallClock(wall: WallClock, timeZone: string): Date {
+function instantOf(time: ICAL.Time, timeZone: string): Date {
 	const asUTC = Date.UTC(
-		wall.year,
-		wall.month - 1,
-		wall.day,
-		wall.hour,
-		wall.minute,
-		wall.second,
+		time.year,
+		time.month - 1,
+		time.day,
+		time.hour,
+		time.minute,
+		time.second,
 	);
 	let guess = asUTC - zoneOffset(new Date(asUTC), timeZone);
 	guess = asUTC - zoneOffset(new Date(guess), timeZone);
 	return new Date(guess);
 }
 
-function toICALTime(wall: WallClock, isDate: boolean): ICAL.Time {
-	// Floating time on purpose: the zone is applied afterwards by
-	// instantFromWallClock, which is what keeps the local hour stable across a
-	// daylight saving change.
-	return new ICAL.Time(
-		{
-			year: wall.year,
-			month: wall.month,
-			day: wall.day,
-			hour: isDate ? 0 : wall.hour,
-			minute: isDate ? 0 : wall.minute,
-			second: isDate ? 0 : wall.second,
-			isDate,
-		},
-		ICAL.Timezone.localTimezone,
-	);
-}
-
-function fromICALTime(time: ICAL.Time): WallClock {
-	return {
-		year: time.year,
-		month: time.month,
-		day: time.day,
-		hour: time.hour,
-		minute: time.minute,
-		second: time.second,
-	};
-}
-
 /**
- * The zone an event's `start` has to be read in.
- *
- * A DTSTART without a TZID — a whole-day date, or a floating time — is turned
- * into a `Date` at *local* midnight by ical.js, not at UTC midnight. Reading it
- * back as UTC shifts a whole-day event by a day in any zone east of Greenwich,
- * which is how a birthday ends up reported one day early.
- *
- * A TZID is whatever the writing client put there. Exchange and some older
- * tools emit Windows zone names ("W. Europe Standard Time") that `Intl` refuses,
- * so an unusable zone falls back to the local one rather than throwing and
- * taking the whole query down with it.
+ * The zone an event's `start` has to be read in. A DTSTART without a TZID
+ * becomes a `Date` at *local* midnight, so reading it as UTC moves a whole-day
+ * event a day east of Greenwich. A TZID is whatever the writing client put
+ * there, and Exchange emits Windows zone names `Intl` refuses, so an unusable
+ * one falls back instead of taking the whole query down.
  */
 function zoneOf(event: Event): string {
-	const local = Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
-	const declared = event.startTzid;
-	if (!declared) return local;
+	if (!event.startTzid) return systemZone();
 	try {
-		formatterFor(declared);
-		return declared;
+		formatterFor(event.startTzid);
+		return event.startTzid;
 	} catch {
-		return local;
+		return systemZone();
 	}
 }
 
 /**
- * Identifies an occurrence by its wall clock rather than by an instant.
- *
- * RECURRENCE-ID and EXDATE both name an occurrence in the series' own local
- * terms, and ts-caldav hands them over as a bare `2026-08-21T14:30:00` with the
- * TZID parameter already dropped. Comparing wall clocks sidesteps the missing
- * zone entirely.
+ * Normalises a stored RECURRENCE-ID or EXDATE for comparison. Both name a slot
+ * in the series' own local terms, and ts-caldav drops the TZID parameter on the
+ * way through, so matching happens on the wall clock.
  */
-function occurrenceKey(wall: WallClock, isDate: boolean): string {
-	const day = `${wall.year}-${pad(wall.month)}-${pad(wall.day)}`;
-	return isDate
-		? day
-		: `${day}T${pad(wall.hour)}:${pad(wall.minute)}:${pad(wall.second)}`;
-}
-
-/** Normalises a stored RECURRENCE-ID or EXDATE into the same shape. */
 export function toOccurrenceKey(
 	value: string,
 	isDate: boolean,
 ): string | undefined {
-	const trimmed = value.trim().replace(/Z$/, "");
-	const iso = trimmed.match(
-		/^(\d{4})-(\d{2})-(\d{2})(?:T(\d{2}):(\d{2}):(\d{2}))?/,
-	);
-	const basic = trimmed.match(
-		/^(\d{4})(\d{2})(\d{2})(?:T(\d{2})(\d{2})(\d{2}))?$/,
-	);
-	const m = iso ?? basic;
+	const m = value
+		.trim()
+		.match(/^(\d{4})-?(\d{2})-?(\d{2})(?:T(\d{2}):?(\d{2}):?(\d{2}))?/);
 	if (!m) return undefined;
 	const [, y, mo, d, h = "00", mi = "00", s = "00"] = m;
 	return isDate ? `${y}-${mo}-${d}` : `${y}-${mo}-${d}T${h}:${mi}:${s}`;
@@ -238,113 +169,188 @@ function asArray(value: string | string[] | undefined): string[] {
 	return Array.isArray(value) ? value : [value];
 }
 
-/**
- * Occurrences the series itself declares as skipped.
- *
- * ts-caldav keeps EXDATE in `customFields` and retains only the first value of
- * each property, so a property listing several dates at once contributes just
- * one of them. Excluding what does arrive still beats excluding nothing; the
- * alternative is showing meetings that were cancelled.
- */
 function exceptionKeys(event: Event, isDate: boolean): Set<string> {
 	const keys = new Set<string>();
 	for (const entry of asArray(event.customFields?.exdate)) {
-		for (const piece of entry.split(",")) {
-			const key = toOccurrenceKey(piece, isDate);
-			if (key) keys.add(key);
-		}
+		const key = toOccurrenceKey(entry, isDate);
+		if (key) keys.add(key);
 	}
 	return keys;
 }
 
-/** The RECURRENCE-ID of an event, if it is a replacement for one occurrence. */
-function recurrenceIdOf(event: Event): string | undefined {
+function recurrenceIdKey(event: Event): string | undefined {
 	const raw = event.customFields?.["recurrence-id"];
-	return typeof raw === "string" ? raw : undefined;
+	return typeof raw === "string"
+		? toOccurrenceKey(raw, event.wholeDay === true)
+		: undefined;
+}
+
+/** ts-caldav stringifies `wkst` off ical.js, so it is already the right number. */
+function toRecur(rule: RecurrenceRule): ICAL.Recur | undefined {
+	if (!rule.freq) return undefined;
+	const wkst = Number(rule.wkst);
+	return ICAL.Recur.fromData({
+		freq: rule.freq,
+		...(rule.interval ? { interval: rule.interval } : {}),
+		...(rule.count ? { count: rule.count } : {}),
+		...(rule.until ? { until: ICAL.Time.fromJSDate(rule.until, true) } : {}),
+		...(Number.isInteger(wkst) ? { wkst } : {}),
+		...(rule.byday?.length ? { BYDAY: rule.byday } : {}),
+		...(rule.bymonthday?.length ? { BYMONTHDAY: rule.bymonthday } : {}),
+		...(rule.bymonth?.length ? { BYMONTH: rule.bymonth } : {}),
+	});
 }
 
 /**
- * Start instants of every occurrence of `event` inside `[windowStart, windowEnd)`.
- * A single event yields at most one entry. Expansion runs on the wall clock of
- * the event's own zone, so a weekly 14:00 appointment stays at 14:00 across a
- * daylight saving change instead of drifting by an hour.
+ * Moves the iterator's starting point closer to the window. Seeding at DTSTART
+ * means walking every occurrence since the series began, some 13,000 steps for a
+ * daily series from 1990. Whole periods can be skipped because BYDAY and friends
+ * evaluate the phase inside a period, which the jump preserves.
  *
- * `replaced` holds the keys of occurrences that a separate override event
- * stands in for; those are skipped so a rescheduled meeting is not reported
- * twice, once at its old slot and once at its new one.
+ * Daily and weekly only: monthly and yearly reach the present in a few hundred
+ * steps. COUNT is left alone, because there the position from the start decides
+ * when the series ends. The jump lands one period short so the iterator, not
+ * this arithmetic, picks the first occurrence.
  */
-export function occurrencesWithin(
+function seedNear(
+	start: ICAL.Time,
+	rule: RecurrenceRule,
+	windowStart: Date,
+	timeZone: string,
+): ICAL.Time {
+	if (rule.count) return start;
+	if (rule.freq !== "DAILY" && rule.freq !== "WEEKLY") return start;
+
+	const days =
+		(rule.freq === "WEEKLY" ? 7 : 1) * Math.max(rule.interval ?? 1, 1);
+	const from = Date.UTC(start.year, start.month - 1, start.day);
+	const target = floatingTimeIn(windowStart, timeZone);
+	const to = Date.UTC(target.year, target.month - 1, target.day);
+	const periods = Math.floor((to - from) / (days * DAY_MS)) - 1;
+	if (periods <= 0) return start;
+
+	const moved = start.clone();
+	moved.adjust(periods * days, 0, 0, 0);
+	return moved;
+}
+
+export type Occurrence = {
+	event: Event;
+	start: Date;
+	/** Wall-clock identity of this slot, in the shape of a RECURRENCE-ID. */
+	key: string;
+	/** True for a series occurrence, replacement instances included. */
+	fromSeries: boolean;
+};
+
+function occurrenceStarts(
 	event: Event,
 	windowStart: Date,
 	windowEnd: Date,
-	replaced: ReadonlySet<string> = new Set(),
-): Date[] {
-	const startsInWindow = (instant: Date) =>
-		instant >= windowStart && instant < windowEnd;
-
-	if (!event.recurrenceRule) {
-		return startsInWindow(event.start) ? [event.start] : [];
-	}
-
-	const rruleString = toRRuleString(event.recurrenceRule);
-	if (!rruleString.startsWith("FREQ=")) {
-		// Nothing usable to expand; report the master rather than dropping it.
-		return startsInWindow(event.start) ? [event.start] : [];
-	}
-
+	replaced: ReadonlySet<string>,
+): Array<{ start: Date; key: string }> {
 	const timeZone = zoneOf(event);
 	const isDate = event.wholeDay === true;
+	const rule = event.recurrenceRule;
+	const recur = rule ? toRecur(rule) : undefined;
+
+	if (!recur || !rule) {
+		const inWindow = event.start >= windowStart && event.start < windowEnd;
+		if (!inWindow) return [];
+		const single = floatingTimeIn(event.start, timeZone, isDate);
+		return [{ start: event.start, key: single.toString() }];
+	}
+
 	const skip = exceptionKeys(event, isDate);
-
-	// Compare in wall clock while walking, so reaching a window decades after
-	// the series began costs no zone conversions at all.
-	const margin = WALL_CLOCK_MARGIN_DAYS * 24 * 60 * 60 * 1000;
-	const lower = toICALTime(
-		wallClockIn(new Date(windowStart.getTime() - margin), timeZone),
-		false,
+	const filtering = skip.size > 0 || replaced.size > 0;
+	// Wall clock while walking: reaching a distant window costs no conversions.
+	const lower = floatingTimeIn(
+		new Date(windowStart.getTime() - MARGIN_MS),
+		timeZone,
 	);
-	const upper = toICALTime(
-		wallClockIn(new Date(windowEnd.getTime() + margin), timeZone),
-		false,
+	const upper = floatingTimeIn(
+		new Date(windowEnd.getTime() + MARGIN_MS),
+		timeZone,
+	);
+	const seed = seedNear(
+		floatingTimeIn(event.start, timeZone, isDate),
+		rule,
+		windowStart,
+		timeZone,
 	);
 
-	const iterator = ICAL.Recur.fromString(rruleString).iterator(
-		toICALTime(wallClockIn(event.start, timeZone), isDate),
-	);
-
-	const found: Date[] = [];
+	const found: Array<{ start: Date; key: string }> = [];
+	const iterator = recur.iterator(seed);
 	for (let step = 0; step < MAX_STEPS; step += 1) {
 		const next = iterator.next();
 		if (!next) break;
 		if (next.compare(upper) > 0) break;
 		if (next.compare(lower) < 0) continue;
 
-		const wall = fromICALTime(next);
-		const key = occurrenceKey(wall, isDate);
-		if (skip.has(key) || replaced.has(key)) continue;
+		const key = next.toString();
+		if (filtering && (skip.has(key) || replaced.has(key))) continue;
 
-		const instant = instantFromWallClock(wall, timeZone);
-		if (startsInWindow(instant)) found.push(instant);
+		const start = instantOf(next, timeZone);
+		if (start >= windowStart && start < windowEnd) found.push({ start, key });
 	}
 	return found;
 }
 
 /**
- * Keys of the occurrences that `events` replace, grouped by the uid of the
- * series they belong to.
+ * Start instants of every occurrence inside `[windowStart, windowEnd)`. Prefer
+ * `expandEvents`, which also correlates a series with its replacements.
  */
-export function replacedOccurrences(
+export function occurrencesWithin(
+	event: Event,
+	windowStart: Date,
+	windowEnd: Date,
+	replaced: ReadonlySet<string> = NO_KEYS,
+): Date[] {
+	return occurrenceStarts(event, windowStart, windowEnd, replaced).map(
+		(o) => o.start,
+	);
+}
+
+/**
+ * Expands a calendar's events into the occurrences inside the window, oldest
+ * first. Moving one instance of a series yields two events sharing a uid: the
+ * master with its rule and a replacement carrying RECURRENCE-ID. Seen apart, the
+ * master still expands into the slot the replacement vacated and the meeting is
+ * reported twice, so the correlation lives here rather than in the caller.
+ */
+export function expandEvents(
 	events: readonly Event[],
-): Map<string, Set<string>> {
-	const byUid = new Map<string, Set<string>>();
+	windowStart: Date,
+	windowEnd: Date,
+): Occurrence[] {
+	const replaced = new Map<string, Set<string>>();
 	for (const event of events) {
-		const raw = recurrenceIdOf(event);
-		if (!raw) continue;
-		const key = toOccurrenceKey(raw, event.wholeDay === true);
+		const key = recurrenceIdKey(event);
 		if (!key) continue;
-		const keys = byUid.get(event.uid) ?? new Set<string>();
-		keys.add(key);
-		byUid.set(event.uid, keys);
+		const keys = replaced.get(event.uid);
+		if (keys) keys.add(key);
+		else replaced.set(event.uid, new Set([key]));
 	}
-	return byUid;
+
+	const out: Occurrence[] = [];
+	for (const event of events) {
+		const override = recurrenceIdKey(event);
+		const starts = occurrenceStarts(
+			event,
+			windowStart,
+			windowEnd,
+			replaced.get(event.uid) ?? NO_KEYS,
+		);
+		for (const { start, key } of starts) {
+			out.push({
+				event,
+				start,
+				// A replacement is identified by the slot it stands in for.
+				key: override ?? key,
+				fromSeries: Boolean(event.recurrenceRule) || override !== undefined,
+			});
+		}
+	}
+	out.sort((a, b) => a.start.getTime() - b.start.getTime());
+	return out;
 }


### PR DESCRIPTION
`list-events` answers a query for next week with the `DTSTART` of a series that began two years ago, and the occurrences that actually fall inside the window are missing.

`getEvents` can ask the server to expand a series (RFC 4791 `<C:expand>`), but a server may ignore it, and Open-Xchange does: it returns the master with the `RRULE` intact. I verified that the `<C:expand>` element has no effect there.

This expands client side with the RRULE engine from `ical.js`, already a transitive dependency, now declared directly. Expansion runs on the wall clock of the event's own zone, so a weekly 14:00 appointment stays at 14:00 across a DST change instead of drifting an hour, and a whole-day event keeps its date rather than moving a day east of Greenwich. `EXDATE` is honoured as far as ts-caldav preserves it (it keeps only the first value of each property).

**Behaviour change:** a series now contributes one entry per occurrence, so several entries can share a `uid`. Each entry carries a `recurring` flag. Marked as a breaking change in the commit footer.

Nine unit tests added, including DST and whole-day cases. Verified against mailbox.org: the week that previously reported three 2024 dates now reports the seven actual appointments.
