### PR TITLE
fix: keep whole-day dates stable across an update

### DIFF
--- a/src/tools/update-event.test.ts
+++ b/src/tools/update-event.test.ts
@@ -182,3 +182,92 @@ describe("registerUpdateEvent", () => {
 		expect(passed?.wholeDay).toBe(true);
 	});
 });
+
+describe("registerUpdateEvent whole-day handling", () => {
+	// A VALUE=DATE reaches us as local midnight, so build the fixture that way.
+	const wholeDayEvent: Event = {
+		uid: "trip-1",
+		href: "/f/test-calendar/trip-1.ics",
+		etag: '"trip"',
+		summary: "Trip",
+		start: new Date(2026, 7, 18),
+		end: new Date(2026, 7, 23),
+		wholeDay: true,
+	};
+
+	function run(args: Parameters<ToolHandler>[0]) {
+		const mockClient = {
+			getEventsByHref: vi.fn().mockResolvedValue([wholeDayEvent]),
+			updateEvent: vi.fn().mockResolvedValue({
+				uid: "trip-1",
+				href: wholeDayEvent.href,
+				etag: '"new"',
+				newCtag: "",
+			}),
+		};
+		const { server, getHandler } = makeServer();
+		registerUpdateEvent(mockClient as unknown as CalDAVClient, server);
+		const handler = getHandler();
+		if (!handler) throw new Error("handler not registered");
+		return handler(args).then(() => mockClient);
+	}
+
+	test("keeps the dates when only another field changes", async () => {
+		const client = await run({
+			uid: "trip-1",
+			calendarUrl: "/f/test-calendar/",
+			location: "Somewhere else",
+		});
+
+		expect(client.updateEvent).toHaveBeenCalledWith(
+			"/f/test-calendar/",
+			expect.objectContaining({
+				location: "Somewhere else",
+				// The writer formats these with toISOString() and adds a day to the
+				// end, which reproduces the stored 2026-08-18 to 2026-08-23.
+				start: new Date(Date.UTC(2026, 7, 18)),
+				end: new Date(Date.UTC(2026, 7, 22)),
+			}),
+		);
+	});
+
+	test("leaves an explicitly given date alone", async () => {
+		const client = await run({
+			uid: "trip-1",
+			calendarUrl: "/f/test-calendar/",
+			start: "2026-09-01T00:00:00+02:00",
+		});
+
+		const [, payload] = client.updateEvent.mock.calls[0];
+		expect(payload.start).toEqual(new Date("2026-09-01T00:00:00+02:00"));
+		expect(payload.end).toEqual(new Date(Date.UTC(2026, 7, 22)));
+	});
+
+	test("does not touch the dates of a timed event", async () => {
+		const timed: Event = { ...wholeDayEvent, wholeDay: false };
+		const mockClient = {
+			getEventsByHref: vi.fn().mockResolvedValue([timed]),
+			updateEvent: vi.fn().mockResolvedValue({
+				uid: "trip-1",
+				href: timed.href,
+				etag: '"new"',
+				newCtag: "",
+			}),
+		};
+		const { server, getHandler } = makeServer();
+		registerUpdateEvent(mockClient as unknown as CalDAVClient, server);
+		const handler = getHandler();
+		if (!handler) throw new Error("handler not registered");
+
+		await handler({
+			uid: "trip-1",
+			calendarUrl: "/f/test-calendar/",
+			location: "Somewhere else",
+		});
+
+		expect(mockClient.updateEvent).toHaveBeenCalledWith(
+			"/f/test-calendar/",
+			expect.objectContaining({ start: timed.start, end: timed.end }),
+		);
+	});
+});

--- a/src/tools/update-event.ts
+++ b/src/tools/update-event.ts
@@ -1,7 +1,48 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { CalDAVClient, RecurrenceRule } from "ts-caldav";
+import type { CalDAVClient, Event, RecurrenceRule } from "ts-caldav";
 import { z } from "zod";
 import { hrefFor } from "./caldav-href.js";
+
+/**
+ * Reshapes a stored whole-day boundary into what the writer expects.
+ *
+ * A `VALUE=DATE` reaches us as local midnight, but the writer derives the date
+ * it stores with `toISOString()`, which is a day earlier in any zone east of
+ * UTC. Anchoring the same calendar day at UTC midnight makes that conversion a
+ * no-op.
+ */
+function asStoredDate(value: Date): Date {
+	return new Date(
+		Date.UTC(value.getFullYear(), value.getMonth(), value.getDate()),
+	);
+}
+
+/**
+ * Carries the dates of a whole-day event over an update untouched.
+ *
+ * Two mismatches bite when only, say, the location changes and the caller
+ * passes no dates at all. Besides the `toISOString()` shift above, the reader
+ * reports DTEND exclusively while the writer takes it inclusively and adds the
+ * day back itself. Handing the stored values straight back therefore moves the
+ * event: DTSTART lands a day early, while DTEND survives because the two
+ * errors cancel out. Undo both here, so an untouched date stays untouched.
+ */
+function carryWholeDayDates(
+	existing: Event,
+	start: string | undefined,
+	end: string | undefined,
+): { start?: Date; end?: Date } {
+	const carried: { start?: Date; end?: Date } = {};
+	if (start === undefined) {
+		carried.start = asStoredDate(existing.start);
+	}
+	if (end === undefined && existing.end) {
+		const inclusive = asStoredDate(existing.end);
+		inclusive.setUTCDate(inclusive.getUTCDate() - 1);
+		carried.end = inclusive;
+	}
+	return carried;
+}
 
 type RecurrenceRuleInput = {
 	freq?: "DAILY" | "WEEKLY" | "MONTHLY" | "YEARLY" | undefined;
@@ -99,8 +140,11 @@ export function registerUpdateEvent(client: CalDAVClient, server: McpServer) {
 				throw new Error(`Event not found: ${uid}`);
 			}
 
+			const staysWholeDay = wholeDay ?? existing.wholeDay;
+
 			const updated = await client.updateEvent(calendarUrl, {
 				...existing,
+				...(staysWholeDay && carryWholeDayDates(existing, start, end)),
 				...(summary !== undefined && { summary }),
 				...(start !== undefined && { start: new Date(start) }),
 				...(end !== undefined && { end: new Date(end) }),


### PR DESCRIPTION
Updating only the location of a whole-day event moves it: DTSTART comes back a day early while DTEND stays where it was.

Two mismatches combine when the caller passes no dates and the stored ones are carried over from the existing event:

- A `VALUE=DATE` arrives as *local* midnight, but the date that gets stored is derived with `toISOString()`, which is a day earlier in any zone east of UTC.
- The reader reports DTEND exclusively while the writer takes it inclusively and adds the day back itself.

So the end survives by accident while the start does not. This reshapes the carried values into the form the writer expects, which makes an untouched date stay untouched.

**It also closes a second, pre-existing bug** that the title does not cover. West of UTC the `toISOString()` truncation loses nothing, so `end` was carried through with no inclusive/exclusive correction at all and every update pushed DTEND one day later — a drift that compounds on repeated edits.

Dates the caller supplies explicitly are deliberately left alone: that path is what #91 addresses, and I did not want the two to overlap.

Verified against mailbox.org (Open-Xchange): a whole-day event created for 10 to 12 March keeps both boundaries to the millisecond when only its location is changed. Three tests added; reverting the fix while keeping them fails under both `TZ=UTC` and `TZ=Europe/Berlin`.

One caveat worth knowing: CI runs under `TZ=UTC`, where `new Date(2026, 7, 18)` and `Date.UTC(2026, 7, 18)` are the same instant, so the DTSTART half of the bug cannot be reproduced there. The regression test fails on CI only through the DTEND half. Pinning a non-UTC `TZ` for the test run would close that gap, but that is your call, not something I wanted to change unasked.
