### PR TITLE
fix: stop whole-day events reading as the day before

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Parameters:
 - `calendarUrl`: string
 
 Returns:
-- A list of events that fall within the given timeframe, each containing `uid`, `summary`, `start`, `end`, and optionally `description` and `location`
+- A list of events that fall within the given timeframe, each containing `uid`, `summary`, `start`, `end`, and optionally `description` and `location`. A whole-day event carries `wholeDay: true`, and its `start` and `end` are plain calendar dates (`YYYY-MM-DD`); `end` names the last day the event covers, not the exclusive DTEND, so it is the day create-event and update-event take as their own `end`. Those two require a full ISO 8601 datetime, so add a time and an offset before passing such a date back. Every other event gives `start` and `end` as ISO 8601 instants.
 
 ### create-event
 

--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -19,6 +19,12 @@ function unwrapText(result: unknown): string {
 	return first.text;
 }
 
+function addDays(date: string, days: number): string {
+	const d = new Date(`${date}T00:00:00.000Z`);
+	d.setUTCDate(d.getUTCDate() + days);
+	return d.toISOString().slice(0, 10);
+}
+
 function log(step: string, detail?: unknown) {
 	const suffix =
 		detail === undefined
@@ -182,6 +188,71 @@ async function main() {
 		}),
 	);
 	log("deleted recurring event");
+
+	// Whole-day round trip over more than one day. list-events used to report
+	// the local midnight instant ical.js builds from a VALUE=DATE, which reads
+	// as the previous day in any zone east of UTC, so a correctly stored event
+	// looked shifted. The dates must come back as plain dates, with `end` naming
+	// the last day. Input stays in UTC on purpose: preserving a non-UTC offset
+	// through create-event is a separate fix.
+	const wholeDayStart = new Date(Date.now() + 3 * 24 * 60 * 60 * 1000)
+		.toISOString()
+		.slice(0, 10);
+	const wholeDayEnd = addDays(wholeDayStart, 2);
+	const wholeDayUid = unwrapText(
+		await client.callTool({
+			name: "create-event",
+			arguments: {
+				summary: `caldav-mcp smoke whole-day ${wholeDayStart}`,
+				start: `${wholeDayStart}T00:00:00Z`,
+				end: `${wholeDayEnd}T00:00:00Z`,
+				wholeDay: true,
+				calendarUrl,
+			},
+		}),
+	);
+	log("created whole-day event", {
+		uid: wholeDayUid,
+		start: wholeDayStart,
+		end: wholeDayEnd,
+	});
+
+	const wholeDayListed = JSON.parse(
+		unwrapText(
+			await client.callTool({
+				name: "list-events",
+				arguments: {
+					start: `${addDays(wholeDayStart, -1)}T00:00:00Z`,
+					end: `${addDays(wholeDayEnd, 2)}T00:00:00Z`,
+					calendarUrl,
+				},
+			}),
+		),
+	) as Array<{ uid: string; start: string; end: string; wholeDay?: boolean }>;
+	const foundWholeDay = wholeDayListed.find((e) => e.uid === wholeDayUid);
+	if (!foundWholeDay)
+		throw new Error(`Created whole-day event ${wholeDayUid} not found`);
+	if (
+		foundWholeDay.wholeDay !== true ||
+		foundWholeDay.start !== wholeDayStart ||
+		foundWholeDay.end !== wholeDayEnd
+	) {
+		throw new Error(
+			`Whole-day round trip wrong: expected ${wholeDayStart}..${wholeDayEnd} with wholeDay, got ${JSON.stringify(foundWholeDay)}`,
+		);
+	}
+	log("verified whole-day event dates", {
+		start: foundWholeDay.start,
+		end: foundWholeDay.end,
+	});
+
+	unwrapText(
+		await client.callTool({
+			name: "delete-event",
+			arguments: { uid: wholeDayUid, calendarUrl },
+		}),
+	);
+	log("deleted whole-day event");
 
 	// VTODO round-trip: create → list → complete → update → delete on a
 	// task-capable collection. Tasks often live in a separate VTODO calendar;

--- a/src/tools/list-events.test.ts
+++ b/src/tools/list-events.test.ts
@@ -1,6 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { CalDAVClient } from "ts-caldav";
-import { describe, expect, test, vi } from "vitest";
+import { afterAll, beforeAll, describe, expect, test, vi } from "vitest";
 import { registerListEvents } from "./list-events.js";
 
 type ToolHandler = (params: {
@@ -115,5 +115,120 @@ describe("registerListEvents", () => {
 		expect(events[0]).toHaveProperty("location", "Conference Room A");
 		expect(events[1]).not.toHaveProperty("description");
 		expect(events[1]).not.toHaveProperty("location");
+	});
+});
+
+describe("registerListEvents with whole-day events", () => {
+	// ical.js turns a VALUE=DATE into a Date at local midnight, so east of UTC
+	// the instant sits on the previous day. The zone is pinned because that is
+	// exactly the condition under test: in UTC the bug cannot appear at all, and
+	// the instants below are what a Berlin machine gets back for
+	// DTSTART;VALUE=DATE:20260825 and friends.
+	beforeAll(() => {
+		vi.stubEnv("TZ", "Europe/Berlin");
+	});
+	afterAll(() => {
+		vi.unstubAllEnvs();
+	});
+
+	async function listWholeDay(events: unknown[]) {
+		const mockClient = { getEvents: vi.fn().mockResolvedValue(events) };
+		let toolHandler: ToolHandler | null = null;
+		const server = new McpServer({ name: "test-server", version: "0.1.0" });
+		const originalRegisterTool = server.registerTool.bind(server);
+		server.registerTool = vi.fn(
+			(name: string, config: unknown, handler: ToolHandler) => {
+				if (name === "list-events") toolHandler = handler;
+				return originalRegisterTool(name, config, handler);
+			},
+		) as typeof server.registerTool;
+
+		registerListEvents(mockClient as unknown as CalDAVClient, server);
+		if (!toolHandler) throw new Error("handler not registered");
+
+		const result = await toolHandler({
+			calendarUrl: "/test/calendar/",
+			start: "2026-08-01T00:00:00Z",
+			end: "2026-11-01T00:00:00Z",
+		});
+		return JSON.parse(result.content[0].text);
+	}
+
+	test("reports a multi-day event as calendar dates, last day included", async () => {
+		const events = await listWholeDay([
+			{
+				uid: "holiday",
+				summary: "Family visit",
+				// DTSTART;VALUE=DATE:20260825, DTEND;VALUE=DATE:20260830
+				start: new Date("2026-08-24T22:00:00Z"),
+				end: new Date("2026-08-29T22:00:00Z"),
+				wholeDay: true,
+			},
+		]);
+
+		expect(events).toHaveLength(1);
+		expect(events[0]).toMatchObject({
+			start: "2026-08-25",
+			end: "2026-08-29",
+			wholeDay: true,
+		});
+	});
+
+	test("reports a one-day event with start and end on the same date", async () => {
+		const events = await listWholeDay([
+			{
+				uid: "single",
+				summary: "Public holiday",
+				start: new Date("2026-08-24T22:00:00Z"),
+				end: new Date("2026-08-25T22:00:00Z"),
+				wholeDay: true,
+			},
+		]);
+
+		expect(events[0]).toMatchObject({ start: "2026-08-25", end: "2026-08-25" });
+	});
+
+	test("keeps start and end together when DTEND is missing", async () => {
+		const events = await listWholeDay([
+			{
+				uid: "no-dtend",
+				summary: "Birthday",
+				start: new Date("2026-08-24T22:00:00Z"),
+				end: new Date("2026-08-24T22:00:00Z"),
+				wholeDay: true,
+			},
+		]);
+
+		expect(events[0]).toMatchObject({ start: "2026-08-25", end: "2026-08-25" });
+	});
+
+	test("counts days across a daylight saving change", async () => {
+		const events = await listWholeDay([
+			{
+				uid: "dst",
+				summary: "Autumn break",
+				// 24 to 28 October: CEST at the start, CET at the end, so the raw
+				// difference is five days plus the hour the clock change adds.
+				start: new Date("2026-10-23T22:00:00Z"),
+				end: new Date("2026-10-28T23:00:00Z"),
+				wholeDay: true,
+			},
+		]);
+
+		expect(events[0]).toMatchObject({ start: "2026-10-24", end: "2026-10-28" });
+	});
+
+	test("leaves a timed event as an ISO instant with no wholeDay flag", async () => {
+		const events = await listWholeDay([
+			{
+				uid: "timed",
+				summary: "Doctor",
+				start: new Date("2026-08-24T14:00:00Z"),
+				end: new Date("2026-08-24T14:30:00Z"),
+			},
+		]);
+
+		expect(events[0].start).toBe("2026-08-24T14:00:00.000Z");
+		expect(events[0]).not.toHaveProperty("wholeDay");
 	});
 });

--- a/src/tools/list-events.ts
+++ b/src/tools/list-events.ts
@@ -1,5 +1,5 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { CalDAVClient } from "ts-caldav";
+import type { CalDAVClient, Event } from "ts-caldav";
 import { z } from "zod";
 
 type ListEventsInput = {
@@ -7,6 +7,31 @@ type ListEventsInput = {
 	end: string;
 	calendarUrl: string;
 };
+
+function localDate(instant: Date): string {
+	const month = `${instant.getMonth() + 1}`.padStart(2, "0");
+	const day = `${instant.getDate()}`.padStart(2, "0");
+	return `${instant.getFullYear()}-${month}-${day}`;
+}
+
+/**
+ * The calendar dates a whole-day event covers, last day included.
+ *
+ * A `VALUE=DATE` carries no time and no zone, but ical.js hands it back as a
+ * `Date` at local midnight. Reporting that instant puts the event on the day
+ * before for any zone east of UTC: `20260825` reads as `2026-08-24T22:00:00Z`
+ * in Berlin, so a vacation stored correctly looks shifted. Reading the local
+ * calendar fields undoes the conversion. DTEND is exclusive, so the day before
+ * it is the last one the event covers. A missing DTEND leaves start and end on
+ * the same date.
+ */
+function wholeDaySpan(event: Event) {
+	const lastDay = new Date(event.end);
+	lastDay.setDate(lastDay.getDate() - 1);
+	const start = localDate(event.start);
+	const end = localDate(lastDay);
+	return { start, end: end < start ? start : end, wholeDay: true };
+}
 
 export const listEventsDefinition = {
 	name: "list-events",
@@ -28,7 +53,7 @@ export const listEventsDefinition = {
 		calendarUrl: z.string(),
 	},
 	returns:
-		"A list of events that fall within the given timeframe, each containing `uid`, `summary`, `start`, `end`, and optionally `description` and `location`",
+		"A list of events that fall within the given timeframe, each containing `uid`, `summary`, `start`, `end`, and optionally `description` and `location`. A whole-day event carries `wholeDay: true`, and its `start` and `end` are plain calendar dates (`YYYY-MM-DD`); `end` names the last day the event covers, not the exclusive DTEND, so it is the day create-event and update-event take as their own `end`. Those two require a full ISO 8601 datetime, so add a time and an offset before passing such a date back. Every other event gives `start` and `end` as ISO 8601 instants.",
 } as const;
 
 export function registerListEvents(client: CalDAVClient, server: McpServer) {
@@ -48,8 +73,9 @@ export function registerListEvents(client: CalDAVClient, server: McpServer) {
 			const data = allEvents.map((e) => ({
 				uid: e.uid,
 				summary: e.summary,
-				start: e.start,
-				end: e.end,
+				...(e.wholeDay === true
+					? wholeDaySpan(e)
+					: { start: e.start, end: e.end }),
 				...(e.description && { description: e.description }),
 				...(e.location && { location: e.location }),
 			}));


### PR DESCRIPTION
`list-events` returns the `Date` that ical.js builds from a `VALUE=DATE`. That
date carries no time and no zone, but the `Date` sits at local midnight, so
serialising it to JSON puts the event on the previous day in every zone east of
UTC:

    DTSTART;VALUE=DATE:20260825  ->  "start": "2026-08-24T22:00:00.000Z"

Anything reading the date out of that string, a calling model included, is off
by one. I chased this as a `create-event` bug for a while, because a holiday
that was stored correctly came back looking like it had been created a day
early.

A whole-day event now reports `wholeDay: true` with `start` and `end` as plain
calendar dates. `DTEND` is exclusive, so `end` names the day before it: the last
day the event covers, which is the day `create-event` already takes as its own
`end`. The write schemas still want a full ISO datetime, and the `returns` text
says so. Timed events are untouched.

Before and after, for a holiday from 25 to 29 August:

```diff
- "start": "2026-08-24T22:00:00.000Z", "end": "2026-08-29T22:00:00.000Z"
+ "start": "2026-08-25", "end": "2026-08-29", "wholeDay": true
```

The dates are read off the local calendar fields rather than derived from the
difference between the two instants, so a daylight saving change inside the span
cannot add or lose a day.

Tests cover a multi-day span, a single day, a missing `DTEND`, a span across the
October clock change, and a timed event that must keep its instant. `TZ` is
pinned to `Europe/Berlin` inside that block, because in UTC the bug cannot occur
at all. The smoke harness now round-trips a three-day whole-day event and checks
both dates; its input stays in UTC so it does not depend on #91.

Related, all independent of each other: #91 is the same class of problem on the
create side, #95 on the update side, this one is the read side. It touches the
same `map` as #94, so if that lands first I will rebase.
